### PR TITLE
Small correction in Level::EventSetClockSide: since STRING_KILLS > ST…

### DIFF
--- a/code/game/level.cpp
+++ b/code/game/level.cpp
@@ -1749,7 +1749,7 @@ void Level::EventSetClockSide
 {
 	const_str clockside = ev->GetConstString( 1 );
 
-	if( clockside < STRING_ALLIES || clockside > STRING_DRAW )
+	if( clockside < STRING_ALLIES || clockside > STRING_KILLS)
 	{
 		ScriptError( "clockside must be 'axis', 'allies', 'kills', or 'draw'" );
 	}


### PR DESCRIPTION
…RING_DRAW, the check should be on STRING_KILLS, not STRING_DRAW.