### PR TITLE
Fix generated executable/lib names missing the -dbg postfix on Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if (WITH_CLIENT)
 	### Gamespy dependency
 	target_include_directories(openmohaa PUBLIC "code/qcommon" "code/script" "code/gamespy" "code/server" "code/client" "code/uilib" "code/jpeg-8c")
 	set_target_properties(openmohaa PROPERTIES OUTPUT_NAME "openmohaa${TARGET_BASE_SUFFIX}${TARGET_ARCH_SUFFIX}")
-    set_target_properties(openmohaa PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+	set_target_properties(openmohaa PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
 	target_link_libraries(openmohaa PRIVATE jpeg8)
 	if (USE_OPENAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 
 set(TARGET_BASE_GAME "main")
+set(CMAKE_DEBUG_POSTFIX "-dbg")
 
 if(MSVC)
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
@@ -40,7 +41,6 @@ ELSE()
 ENDIF()
 
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
-	set(TARGET_CONFIG_SUFFIX "-dbg")
 	add_definitions(-D_DEBUG)
 
 	#if(UNIX)
@@ -48,8 +48,6 @@ IF(CMAKE_BUILD_TYPE MATCHES Debug)
 	#	set(CMAKE_ENABLE_EXPORTS ON)
 	#	message(STATUS "Enabling exports on Unix for backtrace")
 	#endif()
-ELSE()
-	set(TARGET_CONFIG_SUFFIX "")
 ENDIF()
 
 # Common stuff
@@ -73,7 +71,8 @@ target_link_libraries(omohaaded PRIVATE syslib)
 target_link_libraries(omohaaded PRIVATE qcommon qcommon_standalone)
 # Gamespy dependency
 target_include_directories(omohaaded PUBLIC "code/qcommon" "code/script" "code/gamespy" "code/server")
-set_target_properties(omohaaded PROPERTIES OUTPUT_NAME "omohaaded${TARGET_BASE_SUFFIX}${TARGET_ARCH_SUFFIX}${TARGET_CONFIG_SUFFIX}")
+set_target_properties(omohaaded PROPERTIES OUTPUT_NAME "omohaaded${TARGET_BASE_SUFFIX}${TARGET_ARCH_SUFFIX}")
+set_target_properties(omohaaded PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
 if (MSVC)
 	target_link_options(omohaaded PRIVATE "/MANIFEST:NO")
@@ -103,7 +102,8 @@ if (WITH_CLIENT)
 
 	### Gamespy dependency
 	target_include_directories(openmohaa PUBLIC "code/qcommon" "code/script" "code/gamespy" "code/server" "code/client" "code/uilib" "code/jpeg-8c")
-	set_target_properties(openmohaa PROPERTIES OUTPUT_NAME "openmohaa${TARGET_BASE_SUFFIX}${TARGET_ARCH_SUFFIX}${TARGET_CONFIG_SUFFIX}")
+	set_target_properties(openmohaa PROPERTIES OUTPUT_NAME "openmohaa${TARGET_BASE_SUFFIX}${TARGET_ARCH_SUFFIX}")
+    set_target_properties(openmohaa PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
 	target_link_libraries(openmohaa PRIVATE jpeg8)
 	if (USE_OPENAL)

--- a/code/cgame/CMakeLists.txt
+++ b/code/cgame/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(fgame)
+project(cgame)
 
 # Shared source files for modules
 set(SOURCES_SHARED
@@ -28,7 +28,7 @@ target_compile_features(cgame PUBLIC c_variadic_macros)
 target_link_libraries(cgame PUBLIC qcommon)
 
 set_target_properties(cgame PROPERTIES PREFIX "${TARGET_PLATFORM_PREFIX}")
-set_target_properties(cgame PROPERTIES OUTPUT_NAME "cgame${TARGET_ARCH_SUFFIX}${TARGET_CONFIG_SUFFIX}")
+set_target_properties(cgame PROPERTIES OUTPUT_NAME "cgame${TARGET_ARCH_SUFFIX}")
 set_target_properties(cgame PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TARGET_BASE_GAME}")
 
 INSTALL(

--- a/code/fgame/CMakeLists.txt
+++ b/code/fgame/CMakeLists.txt
@@ -44,7 +44,7 @@ target_compile_features(fgame PUBLIC c_variadic_macros)
 target_link_libraries(fgame PUBLIC qcommon)
 
 set_target_properties(fgame PROPERTIES PREFIX "${TARGET_PLATFORM_PREFIX}")
-set_target_properties(fgame PROPERTIES OUTPUT_NAME "game${TARGET_ARCH_SUFFIX}${TARGET_CONFIG_SUFFIX}")
+set_target_properties(fgame PROPERTIES OUTPUT_NAME "game${TARGET_ARCH_SUFFIX}")
 set_target_properties(fgame PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${TARGET_BASE_GAME}")
 
 INSTALL(


### PR DESCRIPTION
When using the Visual Studio generators for CMake debug builds, the generated vcxproj files have incorrect TargetName attributes, resulting in the cgame and fgame modules not having the `-dbg` postfix at the end. This forces the user to having to rename them by hand so that the openmohaa executable can properly load them.

This PR fixes the issue so that `-dbg` is appended to all the executables and DLLs when the Debug configuration is selected. I've tested it with the Ninja and Visual Studio generators, they worked great.

On Linux I couldn't get the postfix to appear anywhere, neither without nor with this patch, not sure what's going on there, but at least for Visual Studio it's now sorted out.