### PR TITLE
Implement UIPulldownMenuContainer

### DIFF
--- a/code/uilib/uipopupmenu.cpp
+++ b/code/uilib/uipopupmenu.cpp
@@ -27,6 +27,28 @@ CLASS_DECLARATION( UIWidget, UIPopupMenu, NULL )
 	{ NULL, NULL }
 };
 
+uipopup_type UI_PopupTypeStringToInt(str type)
+{
+	if (type == "event_string")
+	{
+		return UIP_EVENT_STRING;
+	}
+	else if (type == "command")
+	{
+		return UIP_CMD;
+	}
+	else if (type == "cvar")
+	{
+		return UIP_CVAR;
+	}
+	else if (type == "separator")
+	{
+		return UIP_SEPARATOR;
+	}
+
+	return UIP_NONE;
+}
+
 UIPopupMenu::UIPopupMenu()
 {
 	// FIXME: stub

--- a/code/uilib/uipopupmenu.h
+++ b/code/uilib/uipopupmenu.h
@@ -109,5 +109,7 @@ public:
 	void				getPulldown( str title );
 };
 
+uipopup_type UI_PopupTypeStringToInt(str type);
+
 #endif
 

--- a/code/uilib/uipulldownmenucontainer.cpp
+++ b/code/uilib/uipulldownmenucontainer.cpp
@@ -22,14 +22,138 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "ui_local.h"
 
+Event EV_UIPulldownMenuContainer_AddPopup
+(
+	"addpopup",
+	EV_DEFAULT,
+	"ssss",
+	"menuname title type string",
+	"Adds a popup to the list box.\n"
+	"menuname - the name of the menu to add this to\n"
+	"title - the string to display\n"
+	"type - type of item this is (command,cvar,event_name)\n"
+	"string - the data that corresponds to the correct type\n"
+);
+
+Event EV_UIPulldownMenuContainer_MenuShader
+(
+	"menushader",
+	EV_DEFAULT,
+	"ss",
+	"menuname shader",
+	"Adds a menu to the container and sets the shader.\n"
+	"menuname - the name of the menu to add this to\n"
+	"shader - the string to display"
+);
+
+Event EV_UIPulldownMenuContainer_SelectedMenuShader
+(
+	"selmenushader",
+	EV_DEFAULT,
+	"ss",
+	"menuname shader",
+	"Adds a menu to the container and sets the shader when it's selected.\n"
+	"menuname - the name of the menu to add this to\n"
+	"shader - the string to display"
+);
+
+Event EV_UIPulldownMenuContainer_PopupHighlightFGColor
+(
+	"popup_highlight_fgcolor",
+	EV_DEFAULT,
+	"sffff",
+	"menu r g b a",
+	"Set the highlight background color of the popup menu\n"
+	"menu - the name of the popup menu to color\n"
+);
+
+Event EV_UIPulldownMenuContainer_HighlightBGColor
+(
+	"highlight_bgcolor",
+	EV_DEFAULT,
+	"sffff",
+	"menu r g b a",
+	"Set the highlight foreground color of the pulldown menu\n"
+	"menu - the name of the popup menu to color\n"
+);
+
+Event EV_UIPulldownMenuContainer_HighlightFGColor
+(
+	"highlight_fgcolor",
+	EV_DEFAULT,
+	"sffff",
+	"menu r g b a",
+	"Set the highlight background color of the pulldown menu\n"
+	"menu - the name of the popup menu to color\n"
+);
+
+Event EV_UIPulldownMenuContainer_PopupHighlightBGColor
+(
+	"popup_highlight_bgcolor",
+	EV_DEFAULT,
+	"sffff",
+	"menu r g b a",
+	"Set the highlight foreground color of the popup menu\n"
+	"menu - the name of the popup menu to color\n"
+);
+
+Event EV_UIPulldownMenuContainer_PopupFGColor
+(
+	"popup_fgcolor",
+	EV_DEFAULT,
+	"sffff",
+	"menu r g b a",
+	"Set the background color of the popup menu\n"
+	"menu - the name of the popup menu to color\n"
+);
+
+Event EV_UIPulldownMenuContainer_PopupBGColor
+(
+	"popup_bgcolor",
+	EV_DEFAULT,
+	"sffff",
+	"menu r g b a",
+	"Set the foreground color of the popup menu\n"
+	"menu - the name of the popup menu to color\n"
+);
+
 CLASS_DECLARATION( UIWidget, UIPulldownMenuContainer, NULL )
 {
+	{ &EV_UIPulldownMenuContainer_AddPopup,					&UIPulldownMenuContainer::AddPopup					},
+	{ &EV_UIPulldownMenuContainer_MenuShader,				&UIPulldownMenuContainer::SetMenuShader				},
+	{ &EV_UIPulldownMenuContainer_SelectedMenuShader,		&UIPulldownMenuContainer::SetSelectedMenuShader		},
+	{ &EV_UIPulldownMenuContainer_PopupHighlightFGColor,	&UIPulldownMenuContainer::SetPopupHighlightFGColor	},
+	{ &EV_UIPulldownMenuContainer_PopupHighlightBGColor,	&UIPulldownMenuContainer::SetPopupHighlightBGColor	},
+	{ &EV_UIPulldownMenuContainer_PopupFGColor,				&UIPulldownMenuContainer::SetPopupFGColor			},
+	{ &EV_UIPulldownMenuContainer_PopupBGColor,				&UIPulldownMenuContainer::SetPopupBGColor			},
+	{ &EV_UIPulldownMenuContainer_HighlightFGColor,			&UIPulldownMenuContainer::SetHighlightFGColor		},
+	{ &EV_UIPulldownMenuContainer_HighlightBGColor,			&UIPulldownMenuContainer::SetHighlightBGColor		},
+	{ &EV_Layout_VirtualRes,								&UIPulldownMenuContainer::PulldownVirtualRes		},
 	{ NULL, NULL }
 };
 
 UIPulldownMenuContainer::UIPulldownMenuContainer()
 {
-	// FIXME: stub
+	m_menu = new UIPulldownMenu();
+	m_menu->CreateAligned(this, this);
+}
+
+
+UIPulldownMenuContainer::~UIPulldownMenuContainer()
+{
+	for (int i = m_popups.NumObjects(); i > 0; i--)
+	{
+		uipopup_describe* uid = m_popups.ObjectAt(i);
+		m_popups.RemoveObjectAt(i);
+		delete uid;
+	}
+
+	for (int i = m_dataContainer.NumObjects(); i > 0; i--)
+	{
+		char* data = m_dataContainer.ObjectAt(i);
+		m_dataContainer.RemoveObjectAt(i);
+		delete data;
+	}
 }
 
 void UIPulldownMenuContainer::FrameInitialized
@@ -38,7 +162,9 @@ void UIPulldownMenuContainer::FrameInitialized
 	)
 	
 {
-	// FIXME: stub
+	AllowActivate(qfalse);
+	m_menu->setBackgroundColor(m_background_color, qtrue);
+	m_menu->setForegroundColor(m_background_color);
 }
 
 void UIPulldownMenuContainer::setBackgroundAlpha
@@ -47,7 +173,8 @@ void UIPulldownMenuContainer::setBackgroundAlpha
 	)
 
 {
-	// FIXME: stub
+	m_alpha = f;
+	m_menu->setBackgroundAlpha(f);
 }
 
 void UIPulldownMenuContainer::setBackgroundColor
@@ -57,7 +184,8 @@ void UIPulldownMenuContainer::setBackgroundColor
 	)
 
 {
-	// FIXME: stub
+	UIWidget::setBackgroundColor(color, setbordercolor);
+	m_menu->setBackgroundColor(color, setbordercolor);
 }
 
 void UIPulldownMenuContainer::setForegroundColor
@@ -66,7 +194,8 @@ void UIPulldownMenuContainer::setForegroundColor
 	)
 
 {
-	// FIXME: stub
+	UIWidget::setForegroundColor(color);
+	m_menu->setForegroundColor(color);
 }
 
 void UIPulldownMenuContainer::SetPopupHighlightFGColor
@@ -75,7 +204,13 @@ void UIPulldownMenuContainer::SetPopupHighlightFGColor
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	float r = ev->GetFloat(2);
+	float g = ev->GetFloat(3);
+	float b = ev->GetFloat(4);
+	float a = ev->GetFloat(5);
+
+	m_menu->setPopupHighlightFGColor(menu, UColor(r, g, b, a));
 }
 
 void UIPulldownMenuContainer::SetPopupHighlightBGColor
@@ -84,7 +219,13 @@ void UIPulldownMenuContainer::SetPopupHighlightBGColor
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	float r = ev->GetFloat(2);
+	float g = ev->GetFloat(3);
+	float b = ev->GetFloat(4);
+	float a = ev->GetFloat(5);
+
+	m_menu->setPopupHighlightBGColor(menu, UColor(r, g, b, a));
 }
 
 void UIPulldownMenuContainer::SetPopupFGColor
@@ -93,7 +234,13 @@ void UIPulldownMenuContainer::SetPopupFGColor
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	float r = ev->GetFloat(2);
+	float g = ev->GetFloat(3);
+	float b = ev->GetFloat(4);
+	float a = ev->GetFloat(5);
+
+	m_menu->setPopupFGColor(menu, UColor(r, g, b, a));
 }
 
 void UIPulldownMenuContainer::SetPopupBGColor
@@ -102,7 +249,13 @@ void UIPulldownMenuContainer::SetPopupBGColor
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	float r = ev->GetFloat(2);
+	float g = ev->GetFloat(3);
+	float b = ev->GetFloat(4);
+	float a = ev->GetFloat(5);
+
+	m_menu->setPopupBGColor(menu, UColor(r, g, b, a));
 }
 
 void UIPulldownMenuContainer::SetHighlightFGColor
@@ -111,7 +264,13 @@ void UIPulldownMenuContainer::SetHighlightFGColor
 	)
 
 {
-	// FIXME: stub
+	// original game goes 1-4 for some reason
+	float r = ev->GetFloat(2);
+	float g = ev->GetFloat(3);
+	float b = ev->GetFloat(4);
+	float a = ev->GetFloat(5);
+
+	m_menu->setHighlightFGColor(UColor(r, g, b, a));
 }
 
 void UIPulldownMenuContainer::SetHighlightBGColor
@@ -120,7 +279,13 @@ void UIPulldownMenuContainer::SetHighlightBGColor
 	)
 
 {
-	// FIXME: stub
+	// original game goes 1-4 for some reason
+	float r = ev->GetFloat(2);
+	float g = ev->GetFloat(3);
+	float b = ev->GetFloat(4);
+	float a = ev->GetFloat(5);
+
+	m_menu->setHighlightBGColor(UColor(r, g, b, a));
 }
 
 void UIPulldownMenuContainer::SetMenuShader
@@ -129,7 +294,10 @@ void UIPulldownMenuContainer::SetMenuShader
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	str shader = ev->GetString(2);
+	UIReggedMaterial *mat = uWinMan.RegisterShader(shader);
+	m_menu->setPulldownShader(menu, mat);
 }
 
 void UIPulldownMenuContainer::SetSelectedMenuShader
@@ -138,7 +306,10 @@ void UIPulldownMenuContainer::SetSelectedMenuShader
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	str shader = ev->GetString(2);
+	UIReggedMaterial *mat = uWinMan.RegisterShader(shader);
+	m_menu->setSelectedPulldownShader(menu, mat);
 }
 
 void UIPulldownMenuContainer::Realign
@@ -147,7 +318,8 @@ void UIPulldownMenuContainer::Realign
 	)
 
 {
-	// FIXME: stub
+	UIWidget::Realign();
+	m_menu->Realign();
 }
 
 void UIPulldownMenuContainer::PulldownVirtualRes
@@ -156,7 +328,14 @@ void UIPulldownMenuContainer::PulldownVirtualRes
 	)
 
 {
-	// FIXME: stub
+	LayoutVirtualRes(ev);
+
+	if (m_bVirtual)
+	{
+		Event *newEv = new Event(EV_Layout_VirtualRes);
+		newEv->AddInteger(1);
+		m_menu->ProcessEvent(newEv);
+	}
 }
 
 void UIPulldownMenuContainer::AddPopup
@@ -165,6 +344,15 @@ void UIPulldownMenuContainer::AddPopup
 	)
 
 {
-	// FIXME: stub
+	str menu = ev->GetString(1);
+	str title = ev->GetString(2);
+	str t = ev->GetString(3);
+	str d = ev->GetString(4);
+
+	uipopup_type type = UI_PopupTypeStringToInt(t);
+	void *data = (void*)d.c_str();
+	uipopup_describe* uipd = new uipopup_describe(title, type, data, NULL);
+	m_popups.AddObject(uipd);
+	m_menu->AddUIPopupDescribe(menu, uipd);
 }
 

--- a/code/uilib/uipulldownmenucontainer.cpp
+++ b/code/uilib/uipulldownmenucontainer.cpp
@@ -154,6 +154,8 @@ UIPulldownMenuContainer::~UIPulldownMenuContainer()
 		m_dataContainer.RemoveObjectAt(i);
 		delete data;
 	}
+
+	// FIXME: m_menu isn't deleted, possible memory leak!
 }
 
 void UIPulldownMenuContainer::FrameInitialized

--- a/code/uilib/uipulldownmenucontainer.h
+++ b/code/uilib/uipulldownmenucontainer.h
@@ -33,6 +33,7 @@ public:
 	CLASS_PROTOTYPE( UIPulldownMenuContainer );
 
 	UIPulldownMenuContainer();
+	~UIPulldownMenuContainer();
 
 protected:
 	void	FrameInitialized( void ) override;
@@ -53,6 +54,17 @@ protected:
 public:
 	void	AddPopup( Event *ev );
 };
+
+extern Event EV_UIPulldownMenuContainer_AddPopup;
+extern Event EV_UIPulldownMenuContainer_MenuShader;
+extern Event EV_UIPulldownMenuContainer_SelectedMenuShader;
+extern Event EV_UIPulldownMenuContainer_PopupHighlightFGColor;
+extern Event EV_UIPulldownMenuContainer_HighlightBGColor;
+extern Event EV_UIPulldownMenuContainer_HighlightFGColor;
+extern Event EV_UIPulldownMenuContainer_PopupHighlightBGColor;
+extern Event EV_UIPulldownMenuContainer_PopupFGColor;
+extern Event EV_UIPulldownMenuContainer_PopupBGColor;
+extern Event EV_Layout_VirtualRes;
 
 #endif
 

--- a/code/uilib/uipulldownmenucontainer.h
+++ b/code/uilib/uipulldownmenucontainer.h
@@ -55,16 +55,5 @@ public:
 	void	AddPopup( Event *ev );
 };
 
-extern Event EV_UIPulldownMenuContainer_AddPopup;
-extern Event EV_UIPulldownMenuContainer_MenuShader;
-extern Event EV_UIPulldownMenuContainer_SelectedMenuShader;
-extern Event EV_UIPulldownMenuContainer_PopupHighlightFGColor;
-extern Event EV_UIPulldownMenuContainer_HighlightBGColor;
-extern Event EV_UIPulldownMenuContainer_HighlightFGColor;
-extern Event EV_UIPulldownMenuContainer_PopupHighlightBGColor;
-extern Event EV_UIPulldownMenuContainer_PopupFGColor;
-extern Event EV_UIPulldownMenuContainer_PopupBGColor;
-extern Event EV_Layout_VirtualRes;
-
 #endif
 


### PR DESCRIPTION
An implementation of `UIPulldownMenuContainer`.
Pulldown menus are still not yet functional, `UIPopupMenu` will need to be implemented next.
The "knob" shaders aren't drawing properly either, but maybe only due to the missing `UIPopupMenu` implementation.

Also, not sure if the class' events need to be added as externs to its header file or not. I've added them for now but can remove in a later commit if they aren't necessary.