### PR TITLE
Misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ profile
 *.suo
 
 .vs
-out
 code_unfinished/*
+thirdparties/
+code/parser/generated/*

--- a/code/uilib/uilabel.cpp
+++ b/code/uilib/uilabel.cpp
@@ -260,7 +260,7 @@ void UILabel::Draw(void)
 
                 ret = FindLinkString(val);
                 if (ret) {
-                    string = m_linkstrings.ObjectAt(ret)->value;
+                    string = m_linkstrings.ObjectAt(ret)->string;
                 }
             }
         }

--- a/code/uilib/uipopupmenu.h
+++ b/code/uilib/uipopupmenu.h
@@ -35,6 +35,7 @@ public:
 
 	uipopup_describe();
 	uipopup_describe( str title, uipopup_type type, void *data, UIReggedMaterial *material );
+	~uipopup_describe();
 };
 
 inline
@@ -60,6 +61,19 @@ uipopup_describe::uipopup_describe
 	this->type = type;
 	this->data = data;
 	this->material = material;
+}
+
+// NOTE: this is not part of the original game!
+// Added in OPM to properly clean up memory.
+inline
+uipopup_describe::~uipopup_describe()
+{
+	if (this->data)
+	{
+		// clean up strdup'd C-string from memory
+		free(this->data);
+		this->data = NULL;
+	}
 }
 
 class UIPopupMenu : public UIWidget {

--- a/code/uilib/uipulldownmenucontainer.cpp
+++ b/code/uilib/uipulldownmenucontainer.cpp
@@ -143,9 +143,16 @@ UIPulldownMenuContainer::~UIPulldownMenuContainer()
 {
 	for (int i = m_popups.NumObjects(); i > 0; i--)
 	{
-		uipopup_describe* uid = m_popups.ObjectAt(i);
+		uipopup_describe* uipd = m_popups.ObjectAt(i);
 		m_popups.RemoveObjectAt(i);
-		delete uid;
+		if (uipd->data)
+		{
+			// clean up strdup'd C-string from memory
+			free(uipd->data);
+			uipd->data = NULL;
+		}
+
+		delete uipd;
 	}
 
 	for (int i = m_dataContainer.NumObjects(); i > 0; i--)

--- a/code/uilib/uipulldownmenucontainer.cpp
+++ b/code/uilib/uipulldownmenucontainer.cpp
@@ -145,13 +145,6 @@ UIPulldownMenuContainer::~UIPulldownMenuContainer()
 	{
 		uipopup_describe* uipd = m_popups.ObjectAt(i);
 		m_popups.RemoveObjectAt(i);
-		if (uipd->data)
-		{
-			// clean up strdup'd C-string from memory
-			free(uipd->data);
-			uipd->data = NULL;
-		}
-
 		delete uipd;
 	}
 
@@ -364,7 +357,7 @@ void UIPulldownMenuContainer::AddPopup
 	// otherwise `data` will point to junk when `d` is destroyed.
 	// This only seems to run for each popup menu during game startup,
 	// so it doesn't appear to leak memory continuously,
-	// thus not needing manual cleanup.
+	// but it's being cleaned up in uipopup_describe's dtor anyway.
 	void* data = strdup(d);
 
 	uipopup_describe* uipd = new uipopup_describe(title, type, data, NULL);


### PR DESCRIPTION
Some minor fixes that don't necessitate their own separate PRs.

Includes cleanup logic for the strdup'd `uipopup_describe->data` field, .gitignore changes and fixing the text labels next to the pulldown menus to show the proper cvar-linked string.