### PR TITLE
Implement UINotepad

### DIFF
--- a/code/client/cl_uimaprunner.cpp
+++ b/code/client/cl_uimaprunner.cpp
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-Copyright (C) 2023 the OpenMoHAA team
+Copyright (C) 2023-2024 the OpenMoHAA team
 
 This file is part of OpenMoHAA source code.
 
@@ -94,7 +94,7 @@ void PickFile(const char *name, Listener *obj, Event& event)
         currentpath = "";
     }
 
-    picker->Setup("", currentpath, ".*");
+    picker->Setup("", currentpath, ".*", "");
 }
 
 CLASS_DECLARATION(FilePickerClass, ViewSpawnerClass, NULL) {

--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -1659,7 +1659,6 @@ va
 
 does a varargs printf into a temp buffer, so I don't need to have
 varargs versions of all text functions.
-FIXME: make this buffer size safe someday
 ============
 */
 const char *va( const char *format, ... )
@@ -1673,7 +1672,7 @@ const char *va( const char *format, ... )
 	index++;
 
 	va_start( argptr, format );
-	vsprintf( buf, format, argptr );
+	Q_vsnprintf( buf, sizeof(*string), format, argptr );
 	va_end( argptr );
 
 	return buf;

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1188,6 +1188,9 @@ typedef enum {
 
 //=============================================
 
+// get the control character for the given key (moved from sdl_input.c)
+#define CTRL(a) ((a)-'a'+1)
+
 int Q_isprint( int c );
 int Q_islower( int c );
 int Q_isupper( int c );

--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -59,8 +59,6 @@ static int in_eventTime = 0;
 
 static SDL_Window *SDL_window = NULL;
 
-#define CTRL(a) ((a)-'a'+1)
-
 /*
 ===============
 IN_PrintKey

--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1016,6 +1016,8 @@ static void IN_ProcessEvents( void )
 
 				if( key == K_BACKSPACE )
 					Com_QueueEvent( in_eventTime, SE_CHAR, CTRL('h'), 0, 0, NULL );
+				else if (key == K_ENTER || key == K_TAB || key == K_ESCAPE) // mostly used by UINotepad
+					Com_QueueEvent( in_eventTime, SE_CHAR, key, 0, 0, NULL);
 				else if( keys[K_CTRL].down && key >= 'a' && key <= 'z' )
 					Com_QueueEvent( in_eventTime, SE_CHAR, CTRL(key), 0, 0, NULL );
 

--- a/code/uilib/uifont.cpp
+++ b/code/uilib/uifont.cpp
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-Copyright (C) 2015 the OpenMoHAA team
+Copyright (C) 2015-2024 the OpenMoHAA team
 
 This file is part of OpenMoHAA source code.
 
@@ -500,6 +500,7 @@ int UIFont::getCharWidth(unsigned short ch)
 {
     int index;
     int indirected;
+    float widthMul = 1.0f; // Added in OPM for easier readability
 
     if (!m_font) {
         return 0;
@@ -507,6 +508,7 @@ int UIFont::getCharWidth(unsigned short ch)
 
     if (ch == '\t') {
         ch = ' ';
+        widthMul = 3.0f;
     }
 
     if (m_font->numPages) {
@@ -526,11 +528,7 @@ int UIFont::getCharWidth(unsigned short ch)
         index = 0;
     }
 
-    if (ch == '\t') {
-        return m_font->sgl[index]->locations[indirected].size[0] * 256.0 * 3.0;
-    } else {
-        return m_font->sgl[index]->locations[indirected].size[0] * 256.0;
-    }
+    return m_font->sgl[index]->locations[indirected].size[0] * 256.0 * widthMul;
 }
 
 int UIFont::getHeight(const char *text, int maxlen, qboolean bVirtual)
@@ -631,6 +629,7 @@ float UI_FontgetCharWidthf(fontheader_t *font, unsigned short uch)
 {
     int index;
     int indirected;
+    float widthMul = 1.0f; // Added in OPM for easier readability
 
     if (!font) {
         return 0.f;
@@ -638,6 +637,7 @@ float UI_FontgetCharWidthf(fontheader_t *font, unsigned short uch)
 
     if (uch == '\t') {
         uch = ' ';
+        widthMul = 3.0f;
     }
 
     if (font->numPages) {
@@ -657,11 +657,7 @@ float UI_FontgetCharWidthf(fontheader_t *font, unsigned short uch)
         index = 0;
     }
 
-    if (uch == '\t') {
-        return font->sgl[index]->locations[indirected].size[0] * 3.0;
-    } else {
-        return font->sgl[index]->locations[indirected].size[0];
-    }
+    return font->sgl[index]->locations[indirected].size[0] * widthMul;
 }
 
 int UI_FontStringMaxWidth(fontheader_t *pFont, const char *pszString, int iMaxLen)
@@ -674,13 +670,8 @@ int UI_FontStringMaxWidth(fontheader_t *pFont, const char *pszString, int iMaxLe
         return 0;
     }
 
-    i = 0;
-    for (;;) {
-        unsigned short uch = pszString[i++];
-
-        if (uch == 0 || (iMaxLen != -1 && i > iMaxLen)) {
-            break;
-        }
+    for (int i = 0; pszString[i] && (iMaxLen == -1 || i < iMaxLen); i++) {
+        unsigned short uch = pszString[i];
 
         if (UI_FontDBCSIsLeadByte(pFont, uch)) {
             uch = (uch << 8) | pszString[i];
@@ -709,19 +700,13 @@ int UI_FontStringWidth(fontheader_t *pFont, const char *pszString, int iMaxLen)
 {
     float widths    = 0.0;
     float maxwidths = 0.0;
-    int   i;
 
     if (!pFont) {
         return 0;
     }
 
-    i = 0;
-    for (;;) {
-        unsigned short uch = pszString[i++];
-
-        if (uch == 0 || (iMaxLen != -1 && i > iMaxLen)) {
-            break;
-        }
+    for (int i = 0; pszString[i] && (iMaxLen == -1 || i < iMaxLen); i++) {
+        unsigned short uch = pszString[i];
 
         if (UI_FontDBCSIsLeadByte(pFont, uch)) {
             uch = (uch << 8) | pszString[i];

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -708,6 +708,9 @@ void UIMultiLineEdit::CopySelection(void)
         line.CapLength(botsel->column);
         clipText += "\n" + line;
     }
+
+    // FIXME: clipboard not implemented yet
+    uii.Sys_SetClipboard(clipText);
 }
 
 void UIMultiLineEdit::PasteSelection(void)
@@ -715,7 +718,16 @@ void UIMultiLineEdit::PasteSelection(void)
     str sel;
     int i;
 
-    sel = uii.Sys_GetClipboard();
+    // temporary variable added in OPM as str cannot handle NULL assignment
+    // will be removed when Sys_GetClipboard is properly implemented
+    const char *clipboardData = uii.Sys_GetClipboard();
+    if (clipboardData == NULL)
+    {
+        // FIXME: clipboard not implemented yet
+        return;
+    }
+
+    sel = clipboardData;
 
     DeleteSelection();
 

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -201,70 +201,86 @@ void UIMultiLineEdit::Draw(void)
         int  caret = 0;
 
         if (i < topsel->line || i > botsel->line) {
+            // Print regular line without any selection or cursor present
             m_font->setColor(m_foreground_color);
             m_font->Print(0, aty, cur, -1, m_bVirtual);
         } else {
+            // Current line contains cursor and/or selected text
             float linewidth = m_font->getWidth(cur, -1);
 
             if (i > topsel->line && i < botsel->line) {
-                DrawBox(0, aty, linewidth, m_font->getHeight(m_bVirtual), selectionBG, 1.f);
+                // all text in current line is selected, it's part of a larger selection,
+                // print entire line with the selection highlight box around it
+                DrawBox(0.0f, aty, linewidth, m_font->getHeight(m_bVirtual), selectionBG, 1.f);
                 m_font->setColor(selectionColor);
                 m_font->Print(0, aty, Sys_LV_CL_ConvertString(cur), -1, m_bVirtual);
             } else if (i != topsel->line) {
-                if (i == botsel->line) {
-                    int toplen = m_font->getWidth(cur, botsel->column);
+                // part of this line is selected, and selection continues/began above
+                if (i == botsel->line) { // sanity check, should always be true
+                    int toplen = m_font->getWidth(cur, botsel->column); // X coord of highlighting end
                     if (toplen) {
+                        // selection contains text from the beginning of the line,
+                        // print it with the selection highlight box around it
                         m_font->setColor(selectionColor);
                         DrawBox(0, aty, toplen, m_font->getHeight(m_bVirtual), selectionBG, 1.f);
                         m_font->Print(0, aty, cur, botsel->column, m_bVirtual);
                     }
 
-                    if (toplen < linewidth) {
+                    if (toplen < linewidth) { // is there still text on this line after the selection?
                         m_font->setColor(m_foreground_color);
                         m_font->Print(toplen, aty, &cur[botsel->column], -1, m_bVirtual);
                     }
 
                     if (botsel == &m_selection.end) {
+                        // Place cursor at the end of the selection if it was started from above
                         caret = toplen;
                     }
                 }
             } else if (i != botsel->line) {
-                int toplen = m_font->getWidth(cur, topsel->column);
-                if (topsel->column) {
+                // part of this line is selected, and selection continues/began below
+                int toplen = m_font->getWidth(cur, topsel->column); // X coord of highlighting start
+                if (topsel->column) { // is there any text on this line before the selection?
                     m_font->setColor(m_foreground_color);
                     m_font->Print(0, aty, cur, topsel->column, m_bVirtual);
                 }
 
-                if (toplen < linewidth) {
+                if (toplen < linewidth) { // is there any selected text before the end of the line?
+                    // print the selected text with the selection highlight box around it
                     m_font->setColor(selectionColor);
                     DrawBox(toplen, aty, linewidth - toplen, m_font->getHeight(m_bVirtual), selectionBG, 1.f);
                     m_font->Print(toplen, aty, &cur[topsel->column], -1, m_bVirtual);
                 }
 
                 if (topsel == &m_selection.end) {
+                    // Place cursor before the highlight box if selection was made from the bottom up
                     caret = toplen;
                 }
             } else {
+                // current line contains the cursor
                 if (topsel->column == botsel->column) {
+                    // no selection or highlighted text
                     caret = m_font->getWidth(cur, topsel->column);
                     m_font->setColor(m_foreground_color);
                     m_font->Print(0, aty, Sys_LV_CL_ConvertString(cur), -1, m_bVirtual);
                 } else {
-                    int toplen = m_font->getWidth(cur, topsel->column);
-                    int botlen = toplen + m_font->getWidth(&cur[topsel->column], botsel->column - topsel->column);
+                    // selection starts and ends on this line
+                    int toplen = m_font->getWidth(cur, topsel->column); // X coord of highlighting start
+                    int botlen = toplen + m_font->getWidth(&cur[topsel->column], botsel->column - topsel->column); // X coord of selection end
 
-                    if (toplen) {
+                    if (toplen) { // is there any text on this line before the selection?
                         m_font->setColor(m_foreground_color);
                         m_font->Print(0, aty, cur, topsel->column, m_bVirtual);
                     }
 
-                    if (botlen != toplen) {
+                    if (botlen != toplen) { // is the selection wider than 0 pixels? (sanity check, always true)
+                        // print the selected text with the selection highlight box around it
                         DrawBox(toplen, aty, botlen - toplen, m_font->getHeight(m_bVirtual), selectionBG, 1.f);
                         m_font->setColor(selectionColor);
                         m_font->Print(toplen, aty, &cur[topsel->column], botsel->column - topsel->column, m_bVirtual);
                     }
 
-                    if (cur.length() != botsel->column) {
+                    if (cur.length() != botsel->column) { // is there still text on this line after the selection?
+                        // print the leftover text
                         m_font->setColor(m_foreground_color);
 
                         // Fixed in OPM:
@@ -275,8 +291,10 @@ void UIMultiLineEdit::Draw(void)
                         m_font->Print(botlen, aty, &cur[botsel->column], -1, m_bVirtual);
                     }
 
+                    // Place the cursor at the end of the selection...
                     caret = botlen;
                     if (topsel == &m_selection.end) {
+                        // ... except if selection was made from the bottom up
                         caret = toplen;
                     }
                 }
@@ -286,7 +304,8 @@ void UIMultiLineEdit::Draw(void)
             }
         }
 
-        if (m_selection.end.line == i && (uid.time % 750) > 374 && IsActive()) {
+        if (m_selection.end.line == i && (uid.time % 750) >= 375 && IsActive()) {
+            // draw cursor caret
             DrawBox(caret, aty, 2.f, m_font->getHeight(m_bVirtual), UBlack, 1.f);
         }
 

--- a/code/uilib/uinotepad.cpp
+++ b/code/uilib/uinotepad.cpp
@@ -149,7 +149,8 @@ static ctrlevent_s controlEvents[CTRL_EVENT_COUNT] = {
 bool UI_LoadNotepadFile(const char *filename)
 {
     UINotepad *uinp = new UINotepad();
-    if (uinp->Create(NULL, UIRect2D(100.0f, 100.0f, 450.0f, 300.0f), filename)) {
+    UIRect2D  rect  = UIRect2D(100.0f, 100.0f, 450.0f, 300.0f);
+    if (uinp->Create(NULL, rect, filename)) {
         uWinMan.ActivateControl(uinp);
         return true;
     }

--- a/code/uilib/uinotepad.cpp
+++ b/code/uilib/uinotepad.cpp
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-Copyright (C) 2015 the OpenMoHAA team
+Copyright (C) 2015-2024 the OpenMoHAA team
 
 This file is part of OpenMoHAA source code.
 
@@ -22,245 +22,667 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "ui_local.h"
 
-CLASS_DECLARATION( UIMultiLineEdit, UINotepadEdit, NULL )
-{
-	{ NULL, NULL }
+Event EV_Notepad_SaveAs
+(
+    "_notepad_saveas",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Save As..."
+);
+
+Event EV_Notepad_Save
+(
+    "_notepad_save",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Save"
+);
+
+Event EV_Notepad_Open
+(
+    "_notepad_open",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Open"
+);
+
+Event EV_Notepad_OpenFile
+(
+    "openfile",
+    EV_DEFAULT,
+    "s",
+    "nameOfFile",
+    "called to open a file in the notepad"
+);
+
+Event EV_Notepad_Find
+(
+    "_notepad_find",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Find"
+);
+
+Event EV_Notepad_Goto
+(
+    "_notepad_goto",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Go to line"
+);
+
+Event EV_Notepad_Copy
+(
+    "_notepad_copy",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Copy"
+);
+
+Event EV_Notepad_Cut
+(
+    "_notepad_cut",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Cut"
+);
+
+Event EV_Notepad_Paste
+(
+    "_notepad_paste",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Event sent when user selected Paste"
+);
+
+Event W_Notepad_ChildSizeChanged
+(
+    "_notepad_childsizechanged",
+    EV_DEFAULT,
+    NULL,
+    NULL,
+    "Signal that the child area of the floating window has changed"
+);
+
+CLASS_DECLARATION(UIMultiLineEdit, UINotepadEdit, NULL) {
+    {&W_LeftMouseDown, &UINotepadEdit::MousePressed},
+    {NULL,             NULL                        }
 };
 
-bool UI_LoadNotepadFile( const char *filename )
+CLASS_DECLARATION(UIFloatingWindow, UINotepad, NULL) {
+    {&W_Notepad_ChildSizeChanged,       &UINotepad::ChildSizeChanged},
+    {&EV_Notepad_SaveAs,                &UINotepad::SaveAs          },
+    {&EV_Notepad_Save,                  &UINotepad::Save            },
+    {&EV_Notepad_Open,                  &UINotepad::Open            },
+    {&EV_Notepad_OpenFile,              &UINotepad::OpenFile        },
+    {&UIFloatingWindow::W_ClosePressed, &UINotepad::ClosePressed    },
+    {&EV_Notepad_Find,                  &UINotepad::OnFind          },
+    {&EV_Notepad_Goto,                  &UINotepad::OnGoto          },
+    {&EV_Notepad_Copy,                  &UINotepad::OnCopy          },
+    {&EV_Notepad_Paste,                 &UINotepad::OnPaste         },
+    {&EV_Notepad_Cut,                   &UINotepad::OnCut           },
+    {NULL,                              NULL                        }
+};
+
+#define CTRL_EVENT_COUNT 10
+static ctrlevent_s controlEvents[CTRL_EVENT_COUNT] = {
+    {'o',  &EV_Notepad_Open                 },
+    {'s',  &EV_Notepad_Save                 },
+    {'a',  &EV_Notepad_SaveAs               },
+    {'w',  &UIFloatingWindow::W_ClosePressed},
+    {'f',  &EV_Notepad_Find                 },
+    {'g',  &EV_Notepad_Goto                 },
+    {'c',  &EV_Notepad_Copy                 },
+    {'x',  &EV_Notepad_Cut                  },
+    {'v',  &EV_Notepad_Paste                },
+    {NULL, NULL                             },
+};
+
+bool UI_LoadNotepadFile(const char *filename)
 {
-	return false;
+    UINotepad *uinp = new UINotepad();
+    if (uinp->Create(NULL, UIRect2D(100.0f, 100.0f, 450.0f, 300.0f), filename)) {
+        uWinMan.ActivateControl(uinp);
+        return true;
+    }
+
+    if (uinp) {
+        delete uinp;
+    }
+
+    return false;
 }
 
 UINotepadEdit::UINotepadEdit()
 {
-	// FIXME: stub
+    m_notepad = NULL;
 }
 
-void UINotepadEdit::CharEvent
-	(
-	int ch
-	)
-
+void UINotepadEdit::CharEvent(int ch)
 {
-	// FIXME: stub
+    if (!m_notepad->ProcessCharEvent(ch)) {
+        UIMultiLineEdit::CharEvent(ch);
+    }
 }
 
-void UINotepadEdit::setNotepad
-	(
-	UINotepad *notepad
-	)
-
+void UINotepadEdit::setNotepad(UINotepad *notepad)
 {
-	// FIXME: stub
+    m_notepad = notepad;
 }
 
-bool UINotepadEdit::GotoLine
-	(
-	int line
-	)
-
+bool UINotepadEdit::GotoLine(int line)
 {
-	// FIXME: stub
-	return false;
+    if (line < 1 || line - 1 >= m_lines.getCount()) {
+        return false;
+    }
+
+    m_selection.begin.line = m_selection.end.line = line - 1;
+    m_selection.begin.column                      = 0;
+    m_selection.end.column                        = 999999;
+    BoundSelectionPoint(m_selection.end);
+    EnsureSelectionPointVisible(m_selection.end);
+    return true;
 }
 
-bool UINotepadEdit::FindText
-	(
-	const char *text,
-	int offsetFromSel
-	)
-
+bool UINotepadEdit::FindText(const char *text, int offsetFromSel)
 {
-	// FIXME: stub
-	return false;
+    if (!text) {
+        return false;
+    }
+
+    str lowersearch = text;
+    lowersearch.tolower();
+
+    selectionpoint_s *topsel, *botsel;
+    SortSelection(&topsel, &botsel);
+
+    int  foundat       = -1;
+    bool searchfromtop = false;
+
+    // This loop runs at most twice:
+    //  - once for searchfromtop == false,
+    //  - optionally for searchfromtop == true,
+    // but only if text couldn't be found between the cursor and the end of the file
+    while (true) {
+        int i = 0;
+        m_lines.IterateFromHead();
+        for (; m_lines.IsCurrentValid(); i++, m_lines.IterateNext()) {
+            if (i < topsel->line && !searchfromtop) {
+                // skip lines before the cursor if not searching from the top
+                continue;
+            }
+            if (i > topsel->line && searchfromtop) {
+                // no need to continue if we've looped back to the cursor
+                return false;
+            }
+
+            str findin = m_lines.getCurrent();
+            findin.tolower();
+            const char *where = findin.c_str();
+
+            // Added in OPM to avoid code repetition
+            bool searchLineFromCursor = i == topsel->line && !searchfromtop;
+            if (searchLineFromCursor) {
+                // Start searching on the current line, BUT ONLY from the cursor position.
+                // Offset it with the selection offset:
+                // the purpose of this is to prevent matching
+                // on a string that was just found and is still selected,
+                // by offsetting it
+                if (findin.length() <= topsel->column + offsetFromSel) {
+                    // cursor is at the end of the line, nothing left to search in this one
+                    continue;
+                }
+
+                where = &where[topsel->column + offsetFromSel];
+            }
+
+            const char *found = strstr(where, lowersearch);
+
+            if (found) {
+                // use the beginning of the line to calculate where the matched text is
+                foundat = found - where;
+                if (searchLineFromCursor) {
+                    // take cursor pos. into account if a match is found on the same line as the cursor
+                    foundat += topsel->column + offsetFromSel;
+                }
+                break;
+            }
+        }
+
+        if (foundat == -1) {
+            // couldn't find text in current search iteration
+            if (!searchfromtop) {
+                // try searching from the beginning of the document
+                searchfromtop = true;
+                continue;
+            }
+
+            // text not found
+            return false;
+        } else {
+            // jump to found text and select it
+            m_selection.begin.column = foundat;
+            m_selection.end.column   = foundat + strlen(text);
+            m_selection.begin.line = m_selection.end.line = i;
+            EnsureSelectionPointVisible(m_selection.end);
+            return true;
+        }
+    }
 }
 
-void UINotepadEdit::MousePressed
-	(
-	Event *ev
-	)
-
+void UINotepadEdit::MousePressed(Event *ev)
 {
-	// FIXME: stub
+    if (m_notepad->m_state != STATE_TIMED_MESSAGE) {
+        m_notepad->m_state = STATE_NONE;
+    }
+
+    UIMultiLineEdit::MouseDown(ev);
 }
-
-CLASS_DECLARATION( UIFloatingWindow, UINotepad, NULL )
-{
-	{ NULL, NULL }
-};
-
 
 UINotepad::UINotepad()
 {
-	// FIXME: stub
+    m_state  = STATE_NONE;
+    m_edit   = NULL;
+    m_menu   = NULL;
+    m_status = NULL;
 }
 
-void UINotepad::TimeMessage
-	(
-	const char *message,
-	int howlong
-	)
-
+UINotepad::~UINotepad()
 {
-	// FIXME: stub
+    for (int i = m_popups.NumObjects(); i > 0; i--) {
+        Container<uipopup_describe *> *inner = m_popups.ObjectAt(i);
+        for (int j = inner->NumObjects(); j > 0; j--) {
+            uipopup_describe *uipd = inner->ObjectAt(j);
+            inner->RemoveObjectAt(j);
+            // NOTE: `delete uipd` is intentionally missing here!
+            // Since uipds created for this class have data fields
+            // that contain pointers only to static Event objects,
+            // the fields don't need to be cleaned up as they weren't
+            // dynamically allocated in the first place.
+            // See UINotepad::Create for reference.
+            // However, FIXME: the uipds themselves should still
+            // get cleaned up, but that doesn't happen yet.
+        }
+    }
 }
 
-bool UINotepad::OpenFile
-	(
-	const char *filename
-	)
-
+void UINotepad::TimeMessage(const char *message, int howlong)
 {
-	// FIXME: stub
-	return false;
+    m_state             = STATE_TIMED_MESSAGE;
+    m_timedmessage.die  = uid.time + howlong;
+    m_timedmessage.text = message;
 }
 
-bool UINotepad::Create
-	(
-	UIWidget *parent,
-	UIRect2D& rect,
-	const char *filename
-	)
-
+bool UINotepad::OpenFile(const char *filename)
 {
-	// FIXME: stub
-	return false;
+    char *data = NULL;
+    if (!filename || FS_ReadFile(filename, (void **)&data) == -1) {
+        return false;
+    }
+
+    setFileName(filename);
+    if (m_edit) {
+        m_edit->Empty();
+        m_edit->setData(data);
+    }
+
+    FS_FreeFile(data);
+    return true;
 }
 
-void UINotepad::ChildSizeChanged
-	(
-	Event *ev
-	)
-
+bool UINotepad::Create(UIWidget *parent, UIRect2D& rect, const char *filename)
 {
-	// FIXME: stub
+    UIFloatingWindow::Create(parent, rect, "", UColor(0.15f, 0.196f, 0.278f), UHudColor);
+
+    m_edit = new UINotepadEdit();
+    m_edit->setNotepad(this);
+
+    m_edit->InitFrame(getChildSpace(), 0.0f, 0.0f, 20.0f, 20.0f, 0, "verdana-12");
+    m_edit->setBackgroundColor(UWhite, true);
+    m_edit->setForegroundColor(UBlack);
+    m_edit->setFont("verdana-14");
+
+    m_status = new UIStatusBar(WND_ALIGN_BOTTOM, 20.0f);
+    m_status->InitFrame(getChildSpace(), 0.0f, 0.0f, 20.0f, 20.0f, 0, "verdana-12");
+    m_status->EnableSizeBox(this);
+
+    m_menu = new UIPulldownMenu();
+    m_menu->CreateAligned(getChildSpace(), this);
+    // Fixed in OPM: menu text was hard to read when notepad is active
+    //m_menu->setForegroundColor(UBlack);
+    m_menu->setForegroundColor(UHudColor);
+
+    Container<uipopup_describe *> *pops = new Container<uipopup_describe *>();
+
+    uipopup_describe *uipd = new uipopup_describe("Open (Ctrl-O)", UIP_EVENT, &EV_Notepad_Open, NULL);
+    pops->AddObject(uipd);
+    uipd = new uipopup_describe("Save (Ctrl-S)", UIP_EVENT, &EV_Notepad_Save, NULL);
+    pops->AddObject(uipd);
+    uipd = new uipopup_describe("Save As...(Ctrl-A)", UIP_EVENT, &EV_Notepad_SaveAs, NULL);
+    pops->AddObject(uipd);
+
+    uipd = new uipopup_describe(NULL, UIP_SEPARATOR, NULL, NULL);
+    pops->AddObject(uipd);
+
+    uipd = new uipopup_describe("Close (Ctrl-W)", UIP_EVENT, &UIFloatingWindow::W_ClosePressed, NULL);
+    pops->AddObject(uipd);
+
+    m_popups.AddObject(pops);
+    for (int i = 1; i <= pops->NumObjects(); i++) {
+        m_menu->AddUIPopupDescribe("File", pops->ObjectAt(i));
+    }
+
+    pops = new Container<uipopup_describe *>();
+    uipd = new uipopup_describe("Copy (Ctrl-C)", UIP_EVENT, &EV_Notepad_Copy, NULL);
+    pops->AddObject(uipd);
+    uipd = new uipopup_describe("Cut (Ctrl-X)", UIP_EVENT, &EV_Notepad_Cut, NULL);
+    pops->AddObject(uipd);
+    uipd = new uipopup_describe("Paste (Ctrl-V)", UIP_EVENT, &EV_Notepad_Paste, NULL);
+    pops->AddObject(uipd);
+
+    uipd = new uipopup_describe(NULL, UIP_SEPARATOR, NULL, NULL);
+    pops->AddObject(uipd);
+
+    uipd = new uipopup_describe("Find (Ctrl-F)", UIP_EVENT, &EV_Notepad_Find, NULL);
+    pops->AddObject(uipd);
+    uipd = new uipopup_describe("Go to line... (Ctrl-G)", UIP_EVENT, &EV_Notepad_Goto, NULL);
+    pops->AddObject(uipd);
+
+    m_popups.AddObject(pops);
+    for (int i = 1; i <= pops->NumObjects(); i++) {
+        m_menu->AddUIPopupDescribe("Edit", pops->ObjectAt(i));
+    }
+
+    setFileName("");
+    OpenFile(filename);
+    getChildSpace()->Connect(this, W_SizeChanged, W_Notepad_ChildSizeChanged);
+    getChildSpace()->SendSignal(W_SizeChanged);
+    getChildSpace()->AllowActivate(false);
+    return true;
 }
 
-void UINotepad::SaveAs
-	(
-	Event *ev
-	)
-
+void UINotepad::ChildSizeChanged(Event *ev)
 {
-	// FIXME: stub
+    m_menu->Realign();
+    UISize2D menuSize       = m_menu->getSize();
+    UISize2D childSpaceSize = getChildSpace()->getSize();
+
+    UIRect2D frame(0.0f, menuSize.height, childSpaceSize.width, childSpaceSize.height - 20.0f - menuSize.height);
+
+    m_edit->setFrame(frame);
 }
 
-void UINotepad::Save
-	(
-	Event *ev
-	)
-
+void UINotepad::SaveAs(Event *ev)
 {
-	// FIXME: stub
+    m_state          = STATE_SAVE_AS;
+    m_textinput.text = "";
 }
 
-void UINotepad::Open
-	(
-	Event *ev
-	)
-
+void UINotepad::Save(Event *ev)
 {
-	// FIXME: stub
+    if (!m_filename.length()) {
+        SaveAs(NULL);
+    }
+
+    str filecontents;
+    m_edit->getData(filecontents);
+    m_edit->setChanged(false);
+
+    // FIXME: m_filename could be blank
+    FS_WriteTextFile(m_filename, filecontents, filecontents.length());
+
+    str result = "Saved " + m_filename;
+    TimeMessage(result, 3000);
 }
 
-void UINotepad::OpenFile
-	(
-	Event *ev
-	)
-
+void UINotepad::Open(Event *ev)
 {
-	// FIXME: stub
+    PickFile(m_filename, this, EV_Notepad_OpenFile);
 }
 
-void UINotepad::ClosePressed
-	(
-	Event *ev
-	)
-
+void UINotepad::OpenFile(Event *ev)
 {
-	// FIXME: stub
+    OpenFile(ev->GetString(1));
 }
 
-void UINotepad::OnFind
-	(
-	Event *ev
-	)
-
+void UINotepad::ClosePressed(Event *ev)
 {
-	// FIXME: stub
+    uWinMan.ActivateControl(this);
+    if (m_edit->IsChanged()) {
+        m_state          = STATE_CONFIRMCLOSE;
+        m_textinput.text = "y";
+    } else {
+        PostEvent(EV_Remove, 0.0f);
+
+        // Fixed in OPM:
+        // in the original game, the control is not deactivated after removal,
+        // so the already heap-freed UINotepad instance still "reacts" to
+        // KeyEvents and CharEvents, creating a use-after-free scenario
+        // that causes crashes when debug heap is enabled
+        uWinMan.DeactivateCurrentControl();
+    }
 }
 
-void UINotepad::OnGoto
-	(
-	Event *ev
-	)
-
+void UINotepad::OnFind(Event *ev)
 {
-	// FIXME: stub
+    m_state          = STATE_FIND_TEXT;
+    m_textinput.text = m_lastfind;
 }
 
-void UINotepad::OnCopy
-	(
-	Event *ev
-	)
-
+void UINotepad::OnGoto(Event *ev)
 {
-	// FIXME: stub
+    m_state          = STATE_GOTO_LINE;
+    m_textinput.text = "";
 }
 
-void UINotepad::OnPaste
-	(
-	Event *ev
-	)
-
+void UINotepad::OnCopy(Event *ev)
 {
-	// FIXME: stub
+    m_edit->CopySelection();
 }
 
-void UINotepad::OnCut
-	(
-	Event *ev
-	)
-
+void UINotepad::OnPaste(Event *ev)
 {
-	// FIXME: stub
+    m_edit->PasteSelection();
 }
 
-bool UINotepad::ProcessControlEvents
-	(
-	int ch
-	)
-
+void UINotepad::OnCut(Event *ev)
 {
-	// FIXME: stub
-	return false;
+    m_edit->CopySelection();
+    m_edit->DeleteSelection();
 }
 
-bool UINotepad::ProcessCharEvent
-	(
-	int ch
-	)
-
+bool UINotepad::ProcessControlEvents(int ch)
 {
-	// FIXME: stub
-	return false;
+    if (ch < CTRL('a') || ch > CTRL('z')) {
+        // not a control character
+        return false;
+    }
+
+    // Fixed in OPM:
+    // Original code didn't bounds-check controlEvents
+    for (int i = 0; i < CTRL_EVENT_COUNT; i++) {
+        ctrlevent_s *event = &controlEvents[i];
+        if (!event->ev) {
+            // no event assigned
+            return false;
+        }
+
+        if (ch == CTRL(event->ch)) {
+            // found it
+            PostEvent(
+                new Event(*event->ev), 0.0f
+            ); // create a new Event as it will be deleted by ProcessEvent in L_ProcessPendingEvents
+            return true;
+        }
+    }
+
+    return false;
 }
 
-void UINotepad::Draw
-	(
-	void
-	)
-
+bool UINotepad::ProcessCharEvent(int ch)
 {
-	// FIXME: stub
+    if (ProcessControlEvents(ch)) {
+        return true;
+    }
+
+    if (m_state == STATE_NONE || m_state == STATE_TIMED_MESSAGE) {
+        return false;
+    }
+
+    str text;
+    switch (ch) {
+    case '\b': // Backspace
+        m_textinput.text.CapLength(m_textinput.text.length() - 1);
+        break;
+    case K_ENTER:
+        switch (m_state) {
+        case STATE_GOTO_LINE:
+            {
+                if (!m_textinput.text.length()) {
+                    m_state = STATE_NONE;
+                    return true;
+                }
+
+                int line = atoi(m_textinput.text);
+                if (m_edit->GotoLine(line)) {
+                    m_state = STATE_NONE;
+                    return true;
+                }
+
+                text = "Line '" + m_textinput.text + "' doesn't exist.";
+                TimeMessage(text, 3000);
+                break;
+            }
+        case STATE_FIND_TEXT:
+            if (!m_textinput.text.length()) {
+                m_state = STATE_NONE;
+                return true;
+            }
+
+            if (!m_edit->FindText(m_textinput.text, 1)) {
+                text = "Text: '" + m_textinput.text + "' could not be found.";
+                TimeMessage(text, 3000);
+            }
+
+            m_lastfind = m_textinput.text;
+            return true;
+        case STATE_SAVE_AS:
+            m_state = STATE_NONE;
+
+            if (!m_textinput.text.length()) {
+                return true;
+            }
+
+            setFileName(m_textinput.text);
+            Save(NULL);
+            return true;
+        case STATE_CONFIRMCLOSE:
+            {
+                m_state = STATE_NONE;
+
+                if (!m_textinput.text.length()) {
+                    return true;
+                }
+
+                char choice = tolower(m_textinput.text[0]);
+                if (choice != 'n' && choice != 'y') {
+                    return true;
+                }
+
+                if (choice == 'y') {
+                    Save(NULL);
+                }
+
+                // close window
+                PostEvent(new Event(EV_Remove), 0.0f);
+
+                // Fixed in OPM:
+                // in the original game, the control is not deactivated after removal,
+                // so the already heap-freed UINotepad instance still "reacts" to
+                // KeyEvents and CharEvents, creating a use-after-free scenario,
+                // causing crashes when debug heap is enabled
+                uWinMan.DeactivateCurrentControl();
+
+                return true;
+            }
+        default:
+            m_state = STATE_NONE;
+            return true;
+        }
+        return true;
+    case K_ESCAPE:
+    case K_TAB:
+        m_state = STATE_NONE;
+        return true;
+    }
+
+    if (!isprint(ch)) {
+        return true;
+    }
+
+    if (m_state == STATE_CONFIRMCLOSE) {
+        m_textinput.text = "";
+    }
+
+    m_textinput.text += (char)ch;
+    return true;
 }
 
-void UINotepad::setFileName
-	(
-	const char *filename
-	)
-
+void UINotepad::Draw(void)
 {
-	// FIXME: stub
+    UColor out = URed;
+    out.ScaleColor(0.5f);
+    out.ScaleAlpha(0.5f);
+
+    m_status->setBackgroundColor(out, true);
+    m_status->setForegroundColor(UHudColor);
+
+    str text;
+    switch (m_state) {
+    case STATE_GOTO_LINE:
+        text = "Goto line (tab cancels): " + m_textinput.text;
+        break;
+    case STATE_FIND_TEXT:
+        text = "Find text (tab cancels): " + m_textinput.text;
+        break;
+    case STATE_SAVE_AS:
+        text = "Save As (tab cancels): " + m_textinput.text;
+        break;
+    case STATE_CONFIRMCLOSE:
+        text = "Save " + m_filename + "? (yes/no/cancel) " + m_textinput.text;
+        break;
+    case STATE_TIMED_MESSAGE:
+        if (uid.time > m_timedmessage.die) {
+            m_state = STATE_NONE;
+        default:
+            m_status->setBackgroundColor(getBackgroundColor(), true);
+            m_status->setForegroundColor(getForegroundColor()); // Fixed in OPM
+            m_menu->setForegroundColor(getForegroundColor());   // Fixed in OPM
+            UIPoint2D selpoint = m_edit->getEndSelPoint();
+            text               = va("Line %d, column %d", (int)selpoint.y + 1, (int)selpoint.x + 1);
+        } else {
+            m_status->setBackgroundColor(getBackgroundColor(), true);
+            m_status->setForegroundColor(URed);
+            text = m_timedmessage.text;
+        }
+        break;
+    }
+
+    m_status->setTitle(text);
+    UIFloatingWindow::Draw();
+}
+
+void UINotepad::setFileName(const char *filename)
+{
+    str text = str(filename) + " - Notepad";
+    setTitle(text);
+    m_filename = filename;
 }

--- a/code/uilib/uinotepad.h
+++ b/code/uilib/uinotepad.h
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-Copyright (C) 2015 the OpenMoHAA team
+Copyright (C) 2015-2024 the OpenMoHAA team
 
 This file is part of OpenMoHAA source code.
 
@@ -59,6 +59,7 @@ typedef struct ctrlevent_s {
 } ctrlevent_t;
 
 class UINotepad : public UIFloatingWindow {
+	friend class UINotepadEdit; // UINotepadEdit needs m_state
 private:
 	Container<Container<uipopup_describe *> *> m_popups;
 
@@ -80,6 +81,7 @@ protected:
 
 public:
 	UINotepad();
+	~UINotepad();
 
 	bool	OpenFile( const char *filename );
 	bool	Create( UIWidget *parent, UIRect2D& rect, const char *filename );

--- a/code/uilib/uistatus.cpp
+++ b/code/uilib/uistatus.cpp
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-Copyright (C) 2015 the OpenMoHAA team
+Copyright (C) 2015-2024 the OpenMoHAA team
 
 This file is part of OpenMoHAA source code.
 
@@ -161,7 +161,10 @@ UIStatusBar::UIStatusBar
 	alignment_t align,
 	float height
 	)
-	: UIStatusBar()
+	: UIStatusBar() // Fixed in OPM:
+					// original builds didn't call this ctor,
+					// so statusbar text got center-justified due to
+					// m_iFontAlignmentHorizontal defaulting to FONT_JUSTHORZ_CENTER (0)
 
 {
 	AlignBar(align, height);

--- a/code/uilib/uiwinman.cpp
+++ b/code/uilib/uiwinman.cpp
@@ -1,6 +1,6 @@
 /*
 ===========================================================================
-Copyright (C) 2015 the OpenMoHAA team
+Copyright (C) 2015-2024 the OpenMoHAA team
 
 This file is part of OpenMoHAA source code.
 
@@ -525,7 +525,7 @@ qboolean UIWindowManager::KeyEvent(int key, unsigned int time)
 {
     UIWidget *selwidget = NULL;
 
-    if (key == K_TAB && (uii.Sys_IsKeyDown(K_CTRL) || uii.Sys_IsKeyDown(K_DEL))) {
+    if (key == K_TAB && uii.Sys_IsKeyDown(K_CTRL)) {
         UIWidget *wid;
 
         if (m_activeControl && m_activeControl != this) {
@@ -540,13 +540,13 @@ qboolean UIWindowManager::KeyEvent(int key, unsigned int time)
             selwidget = getFirstChild();
         }
 
-        for (wid = selwidget->getNextChild(selwidget); wid != NULL; wid = wid->getNextChild(wid)) {
+        for (wid = getNextChild(selwidget); wid != NULL; wid = getNextChild(wid)) {
             if (!(selwidget->m_flags & WF_ALWAYS_BOTTOM) && selwidget->CanActivate()) {
                 ActivateControl(wid);
                 return true;
             }
         }
-        for (wid = getFirstChild(); wid != selwidget && wid != NULL; wid = wid->getNextChild(wid)) {
+        for (wid = getFirstChild(); wid != selwidget && wid != NULL; wid = getNextChild(wid)) {
             if (!(selwidget->m_flags & WF_ALWAYS_BOTTOM) && selwidget->CanActivate()) {
                 ActivateControl(wid);
                 return true;
@@ -555,7 +555,7 @@ qboolean UIWindowManager::KeyEvent(int key, unsigned int time)
     } else {
         if (m_bindactive) {
             m_bindactive->KeyEvent(key, time);
-        } else if (!m_activeControl || !m_activeControl->KeyEvent(key, time) && (key != K_UPARROW || key != K_DOWNARROW)) {
+        } else if (!(m_activeControl && m_activeControl->KeyEvent(key, time)) && (key == K_DOWNARROW || key == K_UPARROW)) {
             selwidget = m_activeControl;
             if (selwidget && selwidget != this) {
                 for (selwidget = m_activeControl; selwidget != NULL; selwidget = selwidget->getParent()) {


### PR DESCRIPTION
This PR implements the `UINotepad` and `UINotepadEdit` classes while also fixing at least a dozen bugs in uilib.

With it, a mostly usable notepad implementation becomes available in OpenMOHAA, based on the original game's notepad code. There are a few bugs and missing functionality that will need to be taken care of:
- FilePicker doesn't see any files, only dirs, so right now only the currently active scripts and shaders can be edited
- clipboard functionality is missing, copying/cutting/pasting isn't supported yet
- memory leak when destroying the UINotepad instance, `uipd` instances aren't freed
- crash when trying to save a file that doesn't exist yet
- inconsistent auto-focus on cursor movement and window closing/reopening

All these issues will be fixed in subsequent PRs, coming shortly.