### PR TITLE
UINotepad fixes

### DIFF
--- a/code/client/cl_uimaprunner.cpp
+++ b/code/client/cl_uimaprunner.cpp
@@ -83,7 +83,7 @@ void PickFile(const char *name, Listener *obj, Event& event)
     if (name && *name && strchr(name, '/')) {
         currentpath = name;
 
-        for (i = currentpath.length(); i > 0; i--) {
+        for (i = currentpath.length() - 1; i > 0; i--) {
             if (currentpath[i] == '/') {
                 break;
             }

--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -4493,5 +4493,5 @@ void FS_FileTime(const char *filename, char *date, char *size)
         tm.tm_hour < 12 ? 'a' : 'p'
     );
 
-    Q_snprintf(size, 128, "%d", fileSize);
+    Q_snprintf(size, 128, "%ld", fileSize);
 }

--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -35,6 +35,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #ifndef _WIN32
 #   include <sys/types.h>
+#   include <sys/stat.h>
+#   include <errno.h>
 #   include <dirent.h>
 #endif
 
@@ -4445,13 +4447,51 @@ void FS_CanonicalFilename(char* filename)
 	*dest = 0;
 }
 
-void FS_FileTime(const char* filename, char* date, char* size) {
-	const char* ospath;
+void FS_FileTime(const char *filename, char *date, char *size)
+{
+    const char *ospath;
+    struct stat fileStat;
+    int         result = -1;
 
-	date[0] = 0;
-	size[0] = 0;
+    date[0] = 0;
+    size[0] = 0;
 
-	ospath = FS_BuildOSPath(fs_homepath->string, fs_gamedir, filename);
+    // Fixed in OPM:
+    // don't only check the home directory (fs_homepath) for possible files,
+    // but look through all searchpaths
+    //ospath = FS_BuildOSPath(fs_homepath->string, fs_gamedir, filename);
+    for (auto search = fs_searchpaths; search; search = search->next) {
+        if (search->dir != NULL && search->dir->path != NULL) {
+            ospath = FS_BuildOSPath(search->dir->path, fs_gamedir, filename);
+            result = stat(ospath, &fileStat);
+            if (result != -1) {
+                // found the valid file
+                break;
+            }
+        }
+    }
 
-	// FIXME: unimplemented
+    if (result == -1) {
+        int err = errno;
+        return;
+    }
+
+    time_t modTime  = fileStat.st_mtime;
+    off_t  fileSize = fileStat.st_size;
+
+    // FIXME: provide option not to use idiotic date formats
+    tm tm = *localtime(&modTime);
+    Q_snprintf(
+        date,
+        128,
+        "%2d/%02d/%04d %2d:%02d%c",
+        tm.tm_mon + 1,
+        tm.tm_mday,
+        tm.tm_year + 1900,
+        (tm.tm_hour + 12) % 12,
+        tm.tm_min,
+        tm.tm_hour < 12 ? 'a' : 'p'
+    );
+
+    Q_snprintf(size, 128, "%d", fileSize);
 }

--- a/code/sys/sys_main.c
+++ b/code/sys/sys_main.c
@@ -146,26 +146,8 @@ Sys_GetClipboardData
 */
 char *Sys_GetClipboardData(void)
 {
-#ifdef DEDICATED
-	return NULL;
-#else
-	char *data = NULL;
-	char *cliptext;
-
-	if ( ( cliptext = SDL_GetClipboardText() ) != NULL ) {
-		if ( cliptext[0] != '\0' ) {
-			size_t bufsize = strlen( cliptext ) + 1;
-
-			data = Z_Malloc( bufsize );
-			Q_strncpyz( data, cliptext, bufsize );
-
-			// find first listed char and set to '\0'
-			strtok( data, "\n\r\b" );
-		}
-		SDL_free( cliptext );
-	}
-	return data;
-#endif
+    // unused - actual function is implemented in sys_main_new.c
+    return NULL;
 }
 
 #ifdef DEDICATED

--- a/code/uilib/ui_public.h
+++ b/code/uilib/ui_public.h
@@ -124,6 +124,7 @@ typedef struct uiimport_s {
 	const char *( *Key_KeynumToString )( int keynum );
 	const char *( *GetConfigstring )( int index );
 	void ( *UI_CloseDMConsole )( void );
+	void ( *GetClipboardData )( char *buf, int buflen );
 } uiimport_t;
 
 #if 1

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -728,7 +728,6 @@ void UIMultiLineEdit::CopySelection(void)
         clipText += "\n" + line;
     }
 
-    // FIXME: clipboard not implemented yet
     uii.Sys_SetClipboard(clipText);
 }
 
@@ -737,12 +736,11 @@ void UIMultiLineEdit::PasteSelection(void)
     str sel;
     int i;
 
-    // temporary variable added in OPM as str cannot handle NULL assignment
-    // will be removed when Sys_GetClipboard is properly implemented
+    // variable added in OPM as str cannot handle NULL assignment
+    // we can get NULL here if clipboard is empty/couldn't be retrieved
     const char *clipboardData = uii.Sys_GetClipboard();
     if (clipboardData == NULL)
     {
-        // FIXME: clipboard not implemented yet
         return;
     }
 
@@ -753,8 +751,17 @@ void UIMultiLineEdit::PasteSelection(void)
     for (i = 0; i < sel.length(); i++) {
         if (sel[i] == '\n') {
             CharEvent('\r');
+        } else if (sel[i] == '\r') {
+            // Changed in OPM:
+            // NOP, drop CR characters.
+            // On Linux/Mac they aren't present anyway,
+            // on Windows we already have LF chars next to them.
+            // The filtering for CR on the Windows side was originally done
+            // in Sys_GetWholeClipboard with a "manual" selective strcpy,
+            // but here we iterate over all characters of the clipboard anyways,
+            // so this feels like a better place to do the filtering.
         } else {
-            CharEvent(sel[i]);
+            CharEvent(sel[i]); // FIXME: this is VERY slow and jams up the EventQueue!
         }
     }
 }

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -213,7 +213,11 @@ void UIMultiLineEdit::Draw(void)
                 // print entire line with the selection highlight box around it
                 DrawBox(0.0f, aty, linewidth, m_font->getHeight(m_bVirtual), selectionBG, 1.f);
                 m_font->setColor(selectionColor);
-                m_font->Print(0, aty, Sys_LV_CL_ConvertString(cur), -1, m_bVirtual);
+                // Fixed in OPM:
+                // don't spam LOCALIZATION ERROR messages to console
+                // for clicking lines in the opened text document
+                //m_font->Print(0, aty, Sys_LV_CL_ConvertString(cur), -1, m_bVirtual);
+                m_font->Print(0, aty, cur, -1, m_bVirtual);
             } else if (i != topsel->line) {
                 // part of this line is selected, and selection continues/began above
                 if (i == botsel->line) { // sanity check, should always be true
@@ -261,7 +265,11 @@ void UIMultiLineEdit::Draw(void)
                     // no selection or highlighted text
                     caret = m_font->getWidth(cur, topsel->column);
                     m_font->setColor(m_foreground_color);
-                    m_font->Print(0, aty, Sys_LV_CL_ConvertString(cur), -1, m_bVirtual);
+                    // Fixed in OPM:
+                    // don't spam LOCALIZATION ERROR messages to console
+                    // for clicking lines in the opened text document
+                    //m_font->Print(0, aty, Sys_LV_CL_ConvertString(cur), -1, m_bVirtual);
+                    m_font->Print(0, aty, cur, -1, m_bVirtual);
                 } else {
                     // selection starts and ends on this line
                     int toplen = m_font->getWidth(cur, topsel->column); // X coord of highlighting start

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -128,7 +128,13 @@ void UIMultiLineEdit::getData(str& data)
     data = "";
 
     for (i = 0, m_lines.IterateFromHead(); m_lines.IsCurrentValid(); i++, m_lines.IterateNext()) {
-        data += m_lines.getCurrent();
+        str text = m_lines.getCurrent();
+        if (i == 0 && !text.length() && m_lines.getCount() <= 1) {
+            // file is empty
+            return;
+        }
+
+        data += text;
 
         if (i != m_lines.getCount() - 1) {
             data += "\n";

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -634,7 +634,7 @@ void UIMultiLineEdit::DeleteSelection(void)
         EnsureSelectionPointVisible(*topsel);
         return;
     } else if (botsel->line - topsel->line > 1) {
-        for (i = 0, m_lines.IterateFromHead(); m_lines.IsCurrentValid() && i < topsel->line;
+        for (i = 0, m_lines.IterateFromHead(); m_lines.IsCurrentValid() && i < botsel->line;
              i++, m_lines.IterateNext()) {
             if (i > topsel->line) {
                 m_lines.RemoveCurrentSetPrev();

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -748,7 +748,7 @@ void UIMultiLineEdit::CopySelection(void)
         clipText.CapLength(botsel->column - topsel->column);
     } else {
         for (int i = topsel->line + 1; i < botsel->line; ++i) {
-            clipText += LineFromLineNumber(i, 1);
+            clipText += "\n" + LineFromLineNumber(i, 1);
         }
 
         line = LineFromLineNumber(botsel->line, true);

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -327,6 +327,7 @@ void UIMultiLineEdit::Draw(void)
     }
 }
 
+// num is the ZERO-BASED index of the sought line!
 str& UIMultiLineEdit::LineFromLineNumber(int num, bool resetpos)
 {
     static str emptyLine;
@@ -363,9 +364,7 @@ void UIMultiLineEdit::PointToSelectionPoint(const UIPoint2D& p, selectionpoint_t
     float lastWidth  = 0;
 
     clickedLine = m_vertscroll->getTopItem() + p.y / m_font->getHeight(m_bVirtual);
-    if (clickedLine >= m_lines.getCount()) {
-        clickedLine = m_lines.getCount() - 1;
-    }
+    clickedLine = Q_min(clickedLine, m_lines.getCount() - 1);
 
     if (clickedLine < 0) {
         sel.line   = 0;
@@ -462,7 +461,10 @@ void UIMultiLineEdit::EnsureSelectionPointVisible(selectionpoint_t& point)
 
 void UIMultiLineEdit::BoundSelectionPoint(selectionpoint_t& point)
 {
-    point.line = Q_clamp_int(point.line, 0, m_lines.getCount());
+    // since LineFromLineNumber expects a zero-based line index,
+    // clamp it to one less than the number of lines if the selection point
+    // is right at the end of the text document
+    point.line = Q_clamp_int(point.line, 0, m_lines.getCount() - 1);
 
     str& line    = LineFromLineNumber(point.line, true);
     point.column = Q_clamp_int(point.column, 0, line.length());

--- a/code/uilib/uimledit.cpp
+++ b/code/uilib/uimledit.cpp
@@ -360,12 +360,12 @@ void UIMultiLineEdit::PointToSelectionPoint(const UIPoint2D& p, selectionpoint_t
     }
 
     const char *line = LineFromLineNumber(clickedLine, true).c_str();
-    for (i = 0; i < line[i] && totalWidth < p.x; i++) {
+    for (i = 0; line[i] && totalWidth < p.x; i++) {
         lastWidth = m_font->getCharWidth(line[i]);
         totalWidth += lastWidth;
     }
 
-    if (i < line[i] && i) {
+    if (line[i] && i) {
         lastWidth *= 0.5f;
         if (totalWidth - lastWidth >= p.x) {
             i--;

--- a/code/uilib/uinotepad.cpp
+++ b/code/uilib/uinotepad.cpp
@@ -303,14 +303,7 @@ UINotepad::~UINotepad()
         for (int j = inner->NumObjects(); j > 0; j--) {
             uipopup_describe *uipd = inner->ObjectAt(j);
             inner->RemoveObjectAt(j);
-            // NOTE: `delete uipd` is intentionally missing here!
-            // Since uipds created for this class have data fields
-            // that contain pointers only to static Event objects,
-            // the fields don't need to be cleaned up as they weren't
-            // dynamically allocated in the first place.
-            // See UINotepad::Create for reference.
-            // However, FIXME: the uipds themselves should still
-            // get cleaned up, but that doesn't happen yet.
+            delete uipd;
         }
     }
 }

--- a/code/uilib/uinotepad.cpp
+++ b/code/uilib/uinotepad.cpp
@@ -424,13 +424,16 @@ void UINotepad::Save(Event *ev)
 {
     if (!m_filename.length()) {
         SaveAs(NULL);
+        // Fixed in OPM:
+        // devs probably forgot to return here - saving was attempted,
+        // even though there was no filename to save the file with
+        return;
     }
 
     str filecontents;
     m_edit->getData(filecontents);
     m_edit->setChanged(false);
 
-    // FIXME: m_filename could be blank
     FS_WriteTextFile(m_filename, filecontents, filecontents.length());
 
     str result = "Saved " + m_filename;

--- a/code/uilib/uipopupmenu.h
+++ b/code/uilib/uipopupmenu.h
@@ -68,12 +68,19 @@ uipopup_describe::uipopup_describe
 inline
 uipopup_describe::~uipopup_describe()
 {
-	if (this->data)
-	{
-		// clean up strdup'd C-string from memory
-		free(this->data);
-		this->data = NULL;
-	}
+    if (this->data == NULL) {
+        // nothing to clean up
+        return;
+    }
+
+    // only clean up these types of uipds, because:
+    //  - UIP_EVENT types point to static Event instances,
+    //  - UIP_EVENT_STRING types point to already freed Event instances
+    if (this->type == UIP_CMD || this->type == UIP_CVAR) {
+        // clean up strdup'd C-string from memory
+        free(this->data);
+        this->data = NULL;
+    }
 }
 
 class UIPopupMenu : public UIWidget {

--- a/code/uilib/uivertscroll.cpp
+++ b/code/uilib/uivertscroll.cpp
@@ -344,7 +344,11 @@ void UIVertScroll::MouseEnter
 	)
 
 {
-	uWinMan.ActivateControl(this);
+	// Fixed in OPM
+	// Why should hovering over the scrollbar activate the control it's on?
+	// This is more disorienting than useful, also no sane window manager
+	// works like this. Simply clicking into it should be sufficient.
+	//uWinMan.ActivateControl(this);
 }
 
 void UIVertScroll::MouseLeave


### PR DESCRIPTION
This PR fixes several bugs mentioned in the initial UINotepad implementation PR #306.
It was tested on AA, SH & BT on both Windows and Linux.

Notepad functionality should be close to 100% now with a properly working clipboard, reliable text editing, file opening/saving, etc.
Some related UI bugs (like switching focus between windows when hovering) were also fixed.

There are some known minor notepad-related bugs from the original game that are out of the scope of this PR:

- only 4096 characters can be pasted from the clipboard
- in SH & BT's FilePicker, file metadata (date, size) is not shown for files not in the homepath
- `editchshader` command doesn't work
- `editshader` command can't open any file passed to it
- FilePicker sometimes lists both a directory and its subdirectories as if they're on the same level
- FilePicker doesn't see map scripts in pk3s

These might be fixed in a future PR, but no guarantees.