### PR TITLE
Handle bigger offsets in sample_ms_offset()

### DIFF
--- a/code/client/snd_openal_new.cpp
+++ b/code/client/snd_openal_new.cpp
@@ -3212,7 +3212,7 @@ U32 openal_channel::sample_ms_offset()
         return 0;
     }
 
-    return sample_offset() * 1000 / sample_playback_rate();
+    return sample_offset() * 1000ull / sample_playback_rate();
 }
 
 /*


### PR DESCRIPTION
This fixes an issue where when the offset was big enough, the value would overflow and start again from 0.

Fixes #372.