### PR TITLE
Fix sound event being posted with incorrect arguments

### DIFF
--- a/code/fgame/entity.cpp
+++ b/code/fgame/entity.cpp
@@ -3363,7 +3363,7 @@ void Entity::Sound(Event *ev)
         Event *event = new Event(EV_Sound);
 
         for (int i = 1; i <= ev->NumArgs(); i++) {
-            event->AddValue(ev->GetValue(1));
+            event->AddValue(ev->GetValue(i));
         }
 
         PostEvent(event, level.frametime);


### PR DESCRIPTION
The argument wouldn't contain "wait" when necessary, which would cause scripts to be stuck forever waiting for sound to be done

Fixes #384