### PR TITLE
Don't set the entity angles immediately during glue

### DIFF
--- a/code/fgame/entity.cpp
+++ b/code/fgame/entity.cpp
@@ -5319,9 +5319,6 @@ void Entity::glue(Entity *master, qboolean use_my_angles, qboolean can_duck)
     m_pGlueMaster   = master;
     m_bGlueDuckable = can_duck == qtrue;
     master->m_iNumGlues++;
-
-    setAngles(master->angles);
-    setOrigin(master->origin);
 }
 
 void Entity::unglue(void)


### PR DESCRIPTION
The game expects objects to glue and keep their initial angles/origin

Fixes #390 