### PR TITLE
Fix TIKI_ParseAnimations incorrectly swallowing the full animation file

### DIFF
--- a/code/tiki/tiki_parse.cpp
+++ b/code/tiki/tiki_parse.cpp
@@ -439,7 +439,7 @@ void TIKI_ParseAnimations(dloaddef_t *ld)
 
                     if (strstr(token, "}")) {
                         if (!depth) {
-                            continue;
+                            break;
                         }
 
                         depth--;


### PR DESCRIPTION
This fixes missing animations.

Fixes #387 