### PR TITLE
Don't call into the OAL channel in S_OPENAL_GetMusicFilename if QAL init failed

### DIFF
--- a/code/client/snd_openal_new.cpp
+++ b/code/client/snd_openal_new.cpp
@@ -2570,7 +2570,8 @@ S_OPENAL_GetMusicFilename
 */
 const char *S_OPENAL_GetMusicFilename()
 {
-    if (!openal.chan_trig_music.is_playing()) {
+    // Don't call into the channel if QAL initialisation did not succeed.
+    if (!al_initialized || !openal.chan_trig_music.is_playing()) {
         return "";
     }
     return openal.tm_filename;


### PR DESCRIPTION
Prevents a crash upon vid_restart.

Repro steps:

1. Run OMOHAA with `s_openaldriver` set to something that is sure to fail loading.
2. Type `vid_restart` in the console.
3. Observe crash.