### PR TITLE
[macOS / Compiler Fix] Alter offset for Mouse Buttons

### DIFF
--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1140,9 +1140,9 @@ void CL_KeyEvent(int key, qboolean down, unsigned time)
 
     if (key >= K_MOUSE1 && key <= K_MOUSE5) {
         if (down) {
-            cl.mouseButtons |= (1 << (key - K_MOUSE1) % sizeof(cl.mouseButtons));
+            cl.mouseButtons |= (1 << (key - K_MOUSE1) % (sizeof(cl.mouseButtons) * 8));
         } else {
-            cl.mouseButtons &= ~(1 << (key - K_MOUSE1) % sizeof(cl.mouseButtons));
+            cl.mouseButtons &= ~(1 << (key - K_MOUSE1) % (sizeof(cl.mouseButtons) * 8));
         }
 
         if (in_guimouse) {

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1140,9 +1140,9 @@ void CL_KeyEvent(int key, qboolean down, unsigned time)
 
     if (key >= K_MOUSE1 && key <= K_MOUSE5) {
         if (down) {
-            cl.mouseButtons |= (1 << (key - K_MOUSE1) % (sizeof(cl.mouseButtons) * 8));
+            cl.mouseButtons |= (1 << (key - K_MOUSE1));
         } else {
-            cl.mouseButtons &= ~(1 << (key - K_MOUSE1) % (sizeof(cl.mouseButtons) * 8));
+            cl.mouseButtons &= ~(1 << (key - K_MOUSE1));
         }
 
         if (in_guimouse) {

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1140,9 +1140,9 @@ void CL_KeyEvent(int key, qboolean down, unsigned time)
 
     if (key >= K_MOUSE1 && key <= K_MOUSE5) {
         if (down) {
-            cl.mouseButtons |= (1 << (key + (32 - K_MOUSE1)));
+            cl.mouseButtons |= (1 << (key - K_MOUSE1) % sizeof(cl.mouseButtons));
         } else {
-            cl.mouseButtons &= ~(1 << (key + (32 - K_MOUSE1)));
+            cl.mouseButtons &= ~(1 << (key - K_MOUSE1) % sizeof(cl.mouseButtons));
         }
 
         if (in_guimouse) {

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1140,9 +1140,9 @@ void CL_KeyEvent(int key, qboolean down, unsigned time)
 
     if (key >= K_MOUSE1 && key <= K_MOUSE5) {
         if (down) {
-            cl.mouseButtons |= (1 << (key + (256 - K_MOUSE1)));
+            cl.mouseButtons |= (1 << (key + (32 - K_MOUSE1)));
         } else {
-            cl.mouseButtons &= ~(1 << (key + (256 - K_MOUSE1)));
+            cl.mouseButtons &= ~(1 << (key + (32 - K_MOUSE1)));
         }
 
         if (in_guimouse) {


### PR DESCRIPTION
mouseButtons is 32 bits; I think some compilers might've been stepping into prevent UB and wrapped it when it was set to 256 bits, and it may have worked unintentionally, unless I'm missing something obvious 😅.

This patch gets the build artifacts for macOS to work as intended.