### PR TITLE
When loading from save, set the edict model directly rather than loading and resetting animations

### DIFF
--- a/code/fgame/entity.cpp
+++ b/code/fgame/entity.cpp
@@ -5819,7 +5819,7 @@ void Entity::Archive(Archiver& arc)
             // set the brush model
             edict->s.modelindex = atoi(model.c_str() + 1);
         } else {
-            setModel(model);
+            setModel();
         }
     }
 


### PR DESCRIPTION
Fixes #446