### PR TITLE
Only print a warning instead of dropping when the next snapshot is out of range

### DIFF
--- a/code/cgame/cg_snapshot.c
+++ b/code/cgame/cg_snapshot.c
@@ -347,8 +347,10 @@ static snapshot_t *CG_ReadNextSnapshot(void)
     snapshot_t *dest;
 
     if (cg.latestSnapshotNum > cgs.processedSnapshotNum + 1000) {
-        cgi.Error(
-            ERR_DROP, "CG_ReadNextSnapshot: way out of range, %i > %i", cg.latestSnapshotNum, cgs.processedSnapshotNum
+        cgi.Printf(
+            "WARNING: CG_ReadNextSnapshot: way out of range, %i > %i\n",
+            cg.latestSnapshotNum,
+            cgs.processedSnapshotNum
         );
     }
 


### PR DESCRIPTION
Fixes #432 