### PR TITLE
Correct the gamma with the proper destination resolution when resampling

### DIFF
--- a/code/renderer/tr_init.c
+++ b/code/renderer/tr_init.c
@@ -750,7 +750,7 @@ void R_ResampledScreenShot(const char* filename, int destwidth, int destheight) 
 
 	// gamma correct
 	if ( glConfig.deviceSupportsGamma ) {
-		R_GammaCorrect( buffer + 18, 128 * 128 * 3 );
+		R_GammaCorrect( buffer + 18, destheight * destwidth * 3 );
 	}
 
 	ri.FS_WriteFile( filename, buffer, destheight * destwidth * 3 + 18 );


### PR DESCRIPTION
This fixes an issue where resampled screenshots, like save shots, would have a partial gamma correctionn.

Fixes #438.