### PR TITLE
Rework the target list, use a container instead of an hash set so the target list gets archived correctly

### DIFF
--- a/code/fgame/entity.cpp
+++ b/code/fgame/entity.cpp
@@ -2131,49 +2131,21 @@ void Entity::SetTeamEvent(Event *ev)
 
 void Entity::TriggerEvent(Event *ev)
 {
-    const char *name;
-    Event      *event;
-    Entity     *ent;
-    ConSimple  *tlist;
-    int         i;
-    int         num;
+    SimpleEntity *ent;
+    ScriptVariable arrayVar;
+    int i;
 
-    name = ev->GetString(1);
+    arrayVar = ev->GetValue(1);
+    arrayVar.CastConstArrayValue();
 
-    // Check for object commands
-    if (name && name[0] == '$') {
-        str sName = str(name + 1);
-
-        tlist = world->GetTargetList(sName);
-        num   = tlist->NumObjects();
-        for (i = 1; i <= num; i++) {
-            ent = (Entity *)tlist->ObjectAt(i).Pointer();
-
-            assert(ent);
-
-            event = new Event(EV_Activate);
-
+    for (i = arrayVar.arraysize(); i > 0; i--) {
+        const ScriptVariable *variable = arrayVar[i];
+        ent = variable->simpleEntityValue();
+        if (ent) {
+            Event* event = new Event(EV_Activate);
             event->AddEntity(this);
             ent->ProcessEvent(event);
         }
-    } else if (name[0] == '*') // Check for entnum commands
-    {
-        if (!IsNumeric(&name[1])) {
-            gi.Printf("Expecting numeric value for * command, but found '%s'\n", &name[1]);
-        } else {
-            ent = G_GetEntity(atoi(&name[1]));
-            if (ent) {
-                event = new Event(EV_Activate);
-
-                event->AddEntity(this);
-                ent->ProcessEvent(event);
-            } else {
-                gi.Printf("Entity not found for * command\n");
-            }
-        }
-        return;
-    } else {
-        gi.Printf("Invalid entity reference '%s'.\n", name);
     }
 }
 

--- a/code/fgame/sentient.cpp
+++ b/code/fgame/sentient.cpp
@@ -1121,30 +1121,19 @@ qboolean Sentient::HasSecondaryWeapon(void)
 
 void Sentient::EventGiveTargetname(Event *ev)
 {
-    int         i;
-    ConSimple  *tlist;
-    str         name;
-    const char *ptr;
-    qboolean    found;
+    int i;
+    str name;
+    qboolean found;
+    ScriptVariable var;
+    SimpleEntity *ent;
 
-    name = ev->GetString(1);
+    var = ev->GetValue(1);
+    var.CastConstArrayValue();
 
-    ptr = name.c_str();
-
-    // skip over the $
-    ptr++;
-
-    found = qfalse;
-
-    str sName = ptr;
-    tlist     = world->GetTargetList(sName);
-    for (i = 1; i <= tlist->NumObjects(); i++) {
-        Entity *ent;
-
-        ent = (Entity *)tlist->ObjectAt(i).Pointer();
-        assert(ent);
-
-        if (ent->isSubclassOf(Item)) {
+    for (i = var.arraysize(); i > 0; i--) {
+        const ScriptVariable *variable = var[i];
+        ent = variable->simpleEntityValue();
+        if (ent && ent->IsSubclassOfItem()) {
             Item *item;
 
             item = (Item *)ent;

--- a/code/fgame/simpleentity.cpp
+++ b/code/fgame/simpleentity.cpp
@@ -536,12 +536,18 @@ void SimpleEntity::GetUpVector(Event *ev)
 
 SimpleEntity *SimpleEntity::Next(void)
 {
-    SimpleEntity *ent = world->GetTarget(target, true);
+    Listener* ent;
+    
+    if (!target.length()) {
+        return NULL;
+    }
+
+    ent = world->GetTarget(target, true);
 
     if (!ent || !ent->isSubclassOf(SimpleEntity)) {
         return NULL;
     } else {
-        return ent;
+        return static_cast<SimpleEntity*>(ent);
     }
 }
 

--- a/code/fgame/worldspawn.h
+++ b/code/fgame/worldspawn.h
@@ -97,8 +97,8 @@ public:
 
 class World : public Entity
 {
-    con_set<const_str, ConSimple> m_targetList; // moh could have used con_set instead of TargetList
-    qboolean                      world_dying;
+    Container<TargetList*> m_targetListContainer;
+    qboolean world_dying;
 
 public:
     // farplane variables
@@ -144,17 +144,12 @@ public:
     void FreeTargetList();
 
     SimpleEntity *GetNextEntity(str targetname, SimpleEntity *ent);
-    SimpleEntity *GetNextEntity(const_str targetname, SimpleEntity *ent);
-    SimpleEntity *GetScriptTarget(str targetname);
-    SimpleEntity *GetScriptTarget(const_str targetname);
-    SimpleEntity *GetTarget(str targetname, bool quiet);
-    SimpleEntity *GetTarget(const_str targetname, bool quiet);
+    Listener     *GetScriptTarget(str targetname);
+    Listener     *GetTarget(str targetname, bool quiet);
     int           GetTargetnameIndex(SimpleEntity *ent);
 
-    ConSimple *GetExistingTargetList(const str& targetname);
-    ConSimple *GetExistingTargetList(const_str targetname);
-    ConSimple *GetTargetList(str& targetname);
-    ConSimple *GetTargetList(const_str targetname);
+    TargetList *GetExistingTargetList(const str& targetname);
+    TargetList *GetTargetList(str& targetname);
 
     void SetFarClipOverride(Event *ev);
     void SetFarPlaneColorOverride(Event *ev);

--- a/code/script/scriptvm.cpp
+++ b/code/script/scriptvm.cpp
@@ -1007,7 +1007,7 @@ void ScriptVM::Execute(ScriptVariable *data, int dataSize, str label)
     Event           ev;
     ScriptVariable *var = NULL;
 
-    ConSimple *targetList;
+    TargetList *targetList;
 
     if (Director.stackCount >= MAX_STACK_DEPTH) {
         state = STATE_EXECUTION;
@@ -1769,9 +1769,9 @@ void ScriptVM::Execute(ScriptVariable *data, int dataSize, str label)
 
             case OP_UN_TARGETNAME:
                 // retrieve the target name
-                targetList = world->GetExistingTargetList(m_VMStack.GetTop().constStringValue());
+                targetList = world->GetExistingTargetList(m_VMStack.GetTop().stringValue());
 
-                if (!targetList || !targetList->NumObjects()) {
+                if (!targetList || !targetList->list.NumObjects()) {
                     str targetname = m_VMStack.GetTop().stringValue();
                     // the target name was not found
                     m_VMStack.GetTop().setListenerValue(NULL);
@@ -1780,12 +1780,12 @@ void ScriptVM::Execute(ScriptVariable *data, int dataSize, str label)
                         || (*m_PrevCodePos >= OP_BOOL_UN_NOT && *m_PrevCodePos <= OP_UN_CAST_BOOLEAN)) {
                         ScriptError("Targetname '%s' does not exist.", targetname.c_str());
                     }
-                } else if (targetList->NumObjects() == 1) {
+                } else if (targetList->list.NumObjects() == 1) {
                     // single listener
-                    m_VMStack.GetTop().setListenerValue(targetList->ObjectAt(1));
-                } else if (targetList->NumObjects() > 1) {
+                    m_VMStack.GetTop().setListenerValue(targetList->list.ObjectAt(1));
+                } else if (targetList->list.NumObjects() > 1) {
                     // multiple listeners
-                    m_VMStack.GetTop().setContainerValue((Container<SafePtr<Listener>> *)targetList);
+                    m_VMStack.GetTop().setContainerValue((Container<SafePtr<Listener>> *)&targetList->list);
                 }
                 break;
 


### PR DESCRIPTION
This caused an issue where when loading from a save, a variable referencing target list container would have random entities in it, which would cause issues when trying to do an action on the array of entities

Fixes #443, #444