### PR TITLE
Fix mark fragments being randomly culled or missing, especially on moving brush models

### DIFF
--- a/code/cgame/cg_marks.c
+++ b/code/cgame/cg_marks.c
@@ -787,7 +787,23 @@ void CG_AssembleFinalMarks(
         iFirstNewGroup = 0;
 
         if (mf->iIndex < 0) {
-            VectorSubtract(pMark->pos, cg_entities[-mf->iIndex].lerpOrigin, pMark->pos);
+            centity_t *cent;
+            vec3_t pos;
+
+            cent = &cg_entities[-mf->iIndex];
+
+            VectorSubtract(pMark->pos, cent->lerpOrigin, pos);
+
+            if (cent->lerpAngles[0] || cent->lerpAngles[1] || cent->lerpAngles[2]) {
+                vec3_t axis[3];
+
+                // Fixed in OPM
+                //  Make the position completely local to the entity
+                AngleVectorsLeft(cent->lerpAngles, &axis[0], &axis[1], &axis[2]);
+                MatrixTransformVectorRight(axis, pos, pMark->pos);
+            } else {
+                VectorCopy(pos, pMark->pos);
+            }
         }
 
         pPoly = pMark->markPolys;

--- a/code/renderer/tr_marks.c
+++ b/code/renderer/tr_marks.c
@@ -924,7 +924,7 @@ int R_MarkFragmentsForInlineModel(clipHandle_t bmodel, const vec3_t vAngles, con
 
 	VectorCopy(vTransProjDir, normals[numPoints + 1]);
 	VectorInverse(normals[numPoints + 1]);
-	dists[numPoints + 1] = DotProduct(normals[numPoints + 1], vTransPoints[i]) - 20.f;
+	dists[numPoints + 1] = DotProduct(normals[numPoints + 1], vTransPoints[0]) - 20.f;
 
 	returnedPoints = 0;
 	returnedFragments = 0;


### PR DESCRIPTION
Fixes #480