### PR TITLE
Correctly parse identifiers starting with a number and containing non-numeric characters

### DIFF
--- a/code/parser/lex_source.txt
+++ b/code/parser/lex_source.txt
@@ -190,6 +190,7 @@ static bool UseField( void )
 
 string		([^\\\"\r\n]|\\.)*
 identifier	[^\{\}\(\)\[\]\r\n\,:; \t]
+nonnumeric	[a-zA-Z_\"'?@#`\x80-\xff]
 alphanum	[a-zA-Z0-9_]+
 varname		[a-zA-Z0-9_\"\$]+
 
@@ -312,11 +313,17 @@ varname		[a-zA-Z0-9_\"\$]+
 [\r\n]+							{ if (prev_yylex != TOKEN_EOL) YYLEX(TOKEN_EOL); }
 [ \t]							{ ; }
 
-[0-9^`]+									{
+[0-9]+									{
 											char* p = nullptr;
 											yylval.s.val.intValue = std::strtol(yytext, &p, 10);
 											YYLEX(TOKEN_INTEGER);
 										}
+
+[0-9\.]+{nonnumeric}					{
+											BEGIN(IDENTIFIER);
+											yymore();
+										}
+
 [0-9\.]+|[0-9\.]+("e+"|"e-")+[0-9\.]	{
 											char* p = nullptr;
 											yylval.s.val.floatValue = std::strtof(yytext, &p);


### PR DESCRIPTION
Fixes #551