### PR TITLE
launcher/CMake: Add symlink to bin on Linux

### DIFF
--- a/code/Launcher/CMakeLists.txt
+++ b/code/Launcher/CMakeLists.txt
@@ -22,6 +22,19 @@ function (create_launcher name type)
         set_target_properties(openmohaa_launcher_${name} PROPERTIES OUTPUT_NAME "launch_openmohaa_${name}${TARGET_BIN_SUFFIX}")
 
         INSTALL(TARGETS openmohaa_launcher_${name} DESTINATION ${CMAKE_INSTALL_BINDIR}/${BIN_INSTALL_SUBDIR})
+
+        # Symlink launchers to $PATH
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            INSTALL(CODE "execute_process( \
+                COMMAND ${CMAKE_COMMAND} -E create_symlink \
+                ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/${BIN_INSTALL_SUBDIR}/launch_openmohaa_${name}${TARGET_BIN_SUFFIX} \
+                ${CMAKE_CURRENT_BINARY_DIR}/openmohaa_launcher_${name}.link   \
+            )")
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openmohaa_launcher_${name}.link DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+                RENAME launch_openmohaa_${name}${TARGET_BIN_SUFFIX})
+            install(CODE "file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/openmohaa_launcher_${name}.link)")
+        endif()
+
     endif()
 
     #add_executable(omohaaded_launcher_${name} ${LAUNCHER_SOURCES})


### PR DESCRIPTION
So it's available in $PATH

Since CMAKE_INSTALL_BINDIR is overridden to CMAKE_INSTALL_LIBDIR on Linux, hardcode the bin directory as it's universal.

We also have to do a weird dance of a temporary .link file in the build dir to get this to work correctly for distribution packaging purposes. See https://github.com/zeek/cmake/blob/master/InstallSymlink.cmake#L24