### PR TITLE
Add a client-game variable for customizing the FOV client-side

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -507,6 +507,11 @@ extern "C" {
     extern cvar_t *ui_timemessage;
 
     //
+    // Added in OPM
+    //
+    extern cvar_t *cg_fov;
+
+    //
     // cg_main.c
     //
     qboolean    CG_UseLargeLightmaps(const char* mapName);

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -112,6 +112,11 @@ cvar_t *cg_shadowscount;
 cvar_t *cg_shadowdebug;
 cvar_t *ui_timemessage;
 
+//
+// Added in OPM
+//
+cvar_t *cg_fov;
+
 /*
 =================
 CG_RegisterCvars
@@ -203,6 +208,12 @@ void CG_RegisterCvars(void)
     // see if we are also running the server on this machine
     temp            = cgi.Cvar_Get("sv_running", "0", 0);
     cgs.localServer = temp->integer;
+
+    //
+    // Added in OPM
+    //
+
+    cg_fov = cgi.Cvar_Get("cg_fov", "80", CVAR_ARCHIVE);
 }
 /*
 ===============

--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -330,8 +330,18 @@ static void CG_InterpolatePlayerStateCamera(void)
     //
     VectorCopy(cg.predicted_player_state.camera_angles, cg.camera_angles);
     VectorCopy(cg.predicted_player_state.camera_origin, cg.camera_origin);
-    cg.camera_fov = cg.predicted_player_state.fov;
 
+    //
+    // Added in OPM
+    //  Use the specified fov specified by the server
+    //  when zooming
+    //
+    if (cg.predicted_player_state.stats[STAT_INZOOM]) {
+        cg.camera_fov = cg.predicted_player_state.fov;
+    } else {
+        cg.camera_fov = cg_fov->value;
+    }
+    
     // if the next frame is a teleport, we can't lerp to it
     if (cg.nextFrameCameraCut) {
         return;
@@ -343,8 +353,12 @@ static void CG_InterpolatePlayerStateCamera(void)
 
     f = (float)(cg.time - prev->serverTime) / (next->serverTime - prev->serverTime);
 
-    // interpolate fov
-    cg.camera_fov = prev->ps.fov + f * (next->ps.fov - prev->ps.fov);
+    if (cg.predicted_player_state.stats[STAT_INZOOM]) {
+        // interpolate fov
+        cg.camera_fov = prev->ps.fov + f * (next->ps.fov - prev->ps.fov);
+    } else {
+        cg.camera_fov = cg_fov->value;
+    }
 
     if (!(cg.snap->ps.pm_flags & PMF_CAMERA_VIEW)) {
         return;

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -840,6 +840,15 @@ void CG_DrawActiveFrame(int serverTime, int frameTime, stereoFrame_t stereoView,
         // no entities should be marked as interpolating
     }
 
+    //
+    // Added in OPM
+    //  Clamp the fov to avoid artifacts
+    if (cg_fov->value < 65) {
+        cgi.Cvar_Set("cg_fov", "65");
+    } else if (cg_fov->value > 140) {
+        cgi.Cvar_Set("cg_fov", "120");
+    }
+
     // update cg.predicted_player_state
     CG_PredictPlayerState();
 


### PR DESCRIPTION
A new variable `cg_fov` was introduced to customize the fov client-side, the server-side limitation no longer applies.

Fixes #575