### PR TITLE
fix: fix elapsed time and logged date in loadgame ui

### DIFF
--- a/code/client/cl_uiloadsave.cpp
+++ b/code/client/cl_uiloadsave.cpp
@@ -333,6 +333,7 @@ str FAKKLoadGameItem::getListItemString(int which) const
         {
             int numseconds;
             int numseconds_hours;
+            int seconds;
 
             // hours
             numseconds = atol(strings[1]);
@@ -341,17 +342,18 @@ str FAKKLoadGameItem::getListItemString(int which) const
 
             // minutes
             numseconds_hours = numseconds % 3600;
-            if (numseconds_hours / 60 <= 9) {
+            if (numseconds_hours / 60 < 10) {
                 itemstring += "0";
             }
             itemstring += (numseconds_hours / 60);
             itemstring += ":";
 
             // seconds
-            if (numseconds_hours / 60 <= 9) {
+            seconds = numseconds_hours % 60;
+            if (seconds < 10) {
                 itemstring += "0";
             }
-            itemstring += (numseconds_hours % 60);
+            itemstring += seconds;
         }
         break;
     case 2:
@@ -360,7 +362,7 @@ str FAKKLoadGameItem::getListItemString(int which) const
             char   buffer[2048];
 
             time = atol(strings[2]);
-            strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", localtime(&time));
+            strftime(buffer, sizeof(buffer), "%a %b %d %Y %H:%M:%S", localtime(&time));
             itemstring = buffer;
         }
         break;


### PR DESCRIPTION
fixes #545

Key changes made:

For the elapsed time:
- Fixed the seconds condition to check the actual seconds value instead of minutes
- Added a separate variable for seconds for clarity
- Changed conditions to use < 10 which is more intuitive than <= 9


For the date and time:
- Modified the strftime format string from "%a %b %d %H:%M:%S %Y" to "%a %b %d %Y %H:%M:%S" to put the year before the time

Before the fix:
![CleanShot 2025-02-04 at 22 05 58](https://github.com/user-attachments/assets/b76f7730-d62a-494d-9dc7-8a677b7d9715)

After the fix:
![CleanShot 2025-02-04 at 22 08 13](https://github.com/user-attachments/assets/d5b96f78-04df-4fe8-9055-22155cf5782a)
