### PR TITLE
feat: add GameSpy service unavailable dialog

### DIFF
--- a/code/client/cl_ui.cpp
+++ b/code/client/cl_ui.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../qcommon/q_version.h"
 
 #include "cl_ui.h"
+#include "cl_uigamespy.h"
 
 #include <ctime>
 
@@ -5346,6 +5347,7 @@ void CL_InitializeUI(void)
     Cmd_AddCommand("setreturnmenu", UI_SetReturnMenuToCurrent);
     Cmd_AddCommand("gotoreturnmenu", UI_PushReturnMenu_f);
     Cmd_AddCommand("salesscreen", UI_SalesScreen_f);
+    Cmd_AddCommand("launchgamespy", UI_LaunchGameSpy_f);
 
     if (developer->integer) {
         UColor bgColor;

--- a/code/client/cl_uigamespy.cpp
+++ b/code/client/cl_uigamespy.cpp
@@ -25,17 +25,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 CLASS_DECLARATION(UIFloatingWindow, GameSpyDialog, NULL) {
     {&W_Deactivated, &UIFloatingWindow::ClosePressed},
-    {NULL, NULL}
+    {NULL,           NULL                           }
 };
 
 GameSpyDialog::GameSpyDialog()
     : overlay(NULL)
     , label(NULL)
-    , closeButton(NULL) {
+    , closeButton(NULL)
+{
     AddFlag(WF_ALWAYS_TOP);
 }
 
-GameSpyDialog::~GameSpyDialog() {
+GameSpyDialog::~GameSpyDialog()
+{
     if (overlay) {
         delete overlay;
         overlay = NULL;
@@ -52,44 +54,45 @@ GameSpyDialog::~GameSpyDialog() {
     }
 }
 
-void GameSpyDialog::FrameInitialized(void) {
+void GameSpyDialog::FrameInitialized(void)
+{
     UIFloatingWindow::FrameInitialized();
-    
+
     label = new UILabel();
-    
+
     label->InitFrame(getChildSpace(), getChildSpace()->getClientFrame(), 0);
-    label->setTitle("GameSpy's multiplayer matchmaking\n"
+    label->setTitle(
+        "GameSpy's multiplayer matchmaking\n"
         "and server browsing services, which were\n"
         "essential for online gaming in many classic\n"
         "titles including Medal of Honor: Allied Assault,\n"
-        "were permanently shut down in 2014.");
+        "were permanently shut down in 2014."
+    );
     label->setForegroundColor(UHudColor);
 
     closeButton = new UIButton();
-    closeButton->InitFrame(getChildSpace(), 
-        UIRect2D(100, 150, 100, 30),
-        0);
+    closeButton->InitFrame(getChildSpace(), UIRect2D(100, 150, 100, 30), 0);
     closeButton->setTitle("Close");
     closeButton->AllowActivate(true);
     closeButton->Connect(this, W_Button_Pressed, W_Deactivated);
 
     overlay = new UIButton();
-    overlay->InitFrame(NULL, 
-        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
-        0);    
+    overlay->InitFrame(NULL, UIRect2D(0, 0, uid.vidWidth, uid.vidHeight), 0);
     overlay->setBackgroundColor(UColor(0, 0, 0, 0.5f), true);
     overlay->AllowActivate(true);
-    
+
     overlay->Connect(this, W_Button_Pressed, W_Deactivated);
 }
 
-void GameSpyDialog::Create(UIWidget* parent, const UIRect2D& rect, const char* title, const UColor& bgColor, const UColor& fgColor) 
+void GameSpyDialog::Create(
+    UIWidget *parent, const UIRect2D& rect, const char *title, const UColor& bgColor, const UColor& fgColor
+)
 {
     // First call parent's Create
     UIFloatingWindow::Create(parent, rect, title, bgColor, fgColor);
-    
+
     // After creation, find minimize button by name and hide it
-    for(UIWidget* child = getFirstChild(); child; child = getNextChild(child)) {
+    for (UIWidget *child = getFirstChild(); child; child = getNextChild(child)) {
         if (strcmp(child->getName(), "minimizebutton") == 0) {
             child->setShow(false);
             break;
@@ -97,7 +100,8 @@ void GameSpyDialog::Create(UIWidget* parent, const UIRect2D& rect, const char* t
     }
 }
 
-void UI_LaunchGameSpy_f(void) {
+void UI_LaunchGameSpy_f(void)
+{
     GameSpyDialog *dialog = new GameSpyDialog();
 
     dialog->Create(

--- a/code/client/cl_uigamespy.cpp
+++ b/code/client/cl_uigamespy.cpp
@@ -1,0 +1,109 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+// cl_uigamespy.cpp
+#include "cl_uigamespy.h"
+
+CLASS_DECLARATION(UIFloatingWindow, GameSpyDialog, NULL) {
+    {&W_Deactivated, &UIFloatingWindow::ClosePressed},
+    {NULL, NULL}
+};
+
+GameSpyDialog::GameSpyDialog() {    
+    overlay = new UIButton();
+    overlay->InitFrame(NULL, 
+        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
+        0);    
+    overlay->setBackgroundColor(UColor(0, 0, 0, 0.5f), true);
+    overlay->AllowActivate(true);
+    
+    overlay->Connect(this, W_Button_Pressed, W_Deactivated);
+
+    Connect(this, W_Deactivated, W_Deactivated);
+
+    AddFlag(WF_ALWAYS_TOP);
+}
+
+GameSpyDialog::~GameSpyDialog() {
+    if (overlay) {
+        delete overlay;
+        overlay = NULL;
+    }
+
+    if (label) {
+        delete label;
+        label = NULL;
+    }
+
+    if (closeButton) {
+        delete closeButton;
+        closeButton = NULL;
+    }
+}
+
+void GameSpyDialog::FrameInitialized(void) {
+    UIFloatingWindow::FrameInitialized();
+    
+    label = new UILabel();
+    
+    label->InitFrame(getChildSpace(), getChildSpace()->getClientFrame(), 0);
+    label->setTitle("GameSpy's multiplayer matchmaking\n"
+        "and server browsing services, which were\n"
+        "essential for online gaming in many classic\n"
+        "titles including Medal of Honor: Allied Assault,\n"
+        "were permanently shut down in 2014.");
+    label->setForegroundColor(UHudColor);
+
+    closeButton = new UIButton();
+    closeButton->InitFrame(getChildSpace(), 
+        UIRect2D(100, 150, 100, 30),
+        0);
+    closeButton->setTitle("Close");
+    closeButton->AllowActivate(true);
+    closeButton->Connect(this, W_Button_Pressed, W_Deactivated);
+}
+
+void GameSpyDialog::Create(UIWidget* parent, const UIRect2D& rect, const char* title, const UColor& bgColor, const UColor& fgColor) 
+{
+    // First call parent's Create
+    UIFloatingWindow::Create(parent, rect, title, bgColor, fgColor);
+    
+    // After creation, find minimize button by name and hide it
+    for(UIWidget* child = getFirstChild(); child; child = getNextChild(child)) {
+        if (strcmp(child->getName(), "minimizebutton") == 0) {
+            child->setShow(false);
+            break;
+        }
+    }
+}
+
+void UI_LaunchGameSpy_f(void) {
+    GameSpyDialog *dialog = new GameSpyDialog();
+
+    dialog->Create(
+        NULL,
+        UIRect2D((uid.vidWidth - 300) / 2, (uid.vidHeight - 200) / 2, 300, 200),
+        "GameSpy",
+        UColor(0.15f, 0.195f, 0.278f),
+        UHudColor
+    );
+}

--- a/code/client/cl_uigamespy.cpp
+++ b/code/client/cl_uigamespy.cpp
@@ -28,18 +28,8 @@ CLASS_DECLARATION(UIFloatingWindow, GameSpyDialog, NULL) {
     {NULL, NULL}
 };
 
-GameSpyDialog::GameSpyDialog() {    
-    overlay = new UIButton();
-    overlay->InitFrame(NULL, 
-        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
-        0);    
-    overlay->setBackgroundColor(UColor(0, 0, 0, 0.5f), true);
-    overlay->AllowActivate(true);
-    
-    overlay->Connect(this, W_Button_Pressed, W_Deactivated);
-
-    Connect(this, W_Deactivated, W_Deactivated);
-
+GameSpyDialog::GameSpyDialog()
+    : overlay(NULL) {
     AddFlag(WF_ALWAYS_TOP);
 }
 
@@ -80,6 +70,17 @@ void GameSpyDialog::FrameInitialized(void) {
     closeButton->setTitle("Close");
     closeButton->AllowActivate(true);
     closeButton->Connect(this, W_Button_Pressed, W_Deactivated);
+
+    overlay = new UIButton();
+    overlay->InitFrame(NULL, 
+        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
+        0);    
+    overlay->setBackgroundColor(UColor(0, 0, 0, 0.5f), true);
+    overlay->AllowActivate(true);
+    
+    overlay->Connect(this, W_Button_Pressed, W_Deactivated);
+
+    Connect(this, W_Deactivated, W_Deactivated);
 }
 
 void GameSpyDialog::Create(UIWidget* parent, const UIRect2D& rect, const char* title, const UColor& bgColor, const UColor& fgColor) 

--- a/code/client/cl_uigamespy.cpp
+++ b/code/client/cl_uigamespy.cpp
@@ -29,7 +29,9 @@ CLASS_DECLARATION(UIFloatingWindow, GameSpyDialog, NULL) {
 };
 
 GameSpyDialog::GameSpyDialog()
-    : overlay(NULL) {
+    : overlay(NULL)
+    , label(NULL)
+    , closeButton(NULL) {
     AddFlag(WF_ALWAYS_TOP);
 }
 

--- a/code/client/cl_uigamespy.cpp
+++ b/code/client/cl_uigamespy.cpp
@@ -79,8 +79,6 @@ void GameSpyDialog::FrameInitialized(void) {
     overlay->AllowActivate(true);
     
     overlay->Connect(this, W_Button_Pressed, W_Deactivated);
-
-    Connect(this, W_Deactivated, W_Deactivated);
 }
 
 void GameSpyDialog::Create(UIWidget* parent, const UIRect2D& rect, const char* title, const UColor& bgColor, const UColor& fgColor) 
@@ -107,4 +105,8 @@ void UI_LaunchGameSpy_f(void) {
         UColor(0.15f, 0.195f, 0.278f),
         UHudColor
     );
+
+    uWinMan.ActivateControl(dialog);
+
+    dialog->Connect(dialog, W_Deactivated, W_Deactivated);
 }

--- a/code/client/cl_uigamespy.h
+++ b/code/client/cl_uigamespy.h
@@ -27,19 +27,21 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cl_ui.h"
 #include "keycodes.h"
 
-class GameSpyDialog : public UIFloatingWindow {
+class GameSpyDialog : public UIFloatingWindow
+{
 private:
-    UIButton    *overlay;
-    UILabel     *label;
-    UIButton    *closeButton;
+    UIButton *overlay;
+    UILabel  *label;
+    UIButton *closeButton;
 
 protected:
-	void		FrameInitialized( void ) override;
+    void FrameInitialized(void) override;
 
 public:
     GameSpyDialog();
     ~GameSpyDialog();
-    void Create(UIWidget* parent, const UIRect2D& rect, const char* title, const UColor& bgColor, const UColor& fgColor);
+    void
+    Create(UIWidget *parent, const UIRect2D& rect, const char *title, const UColor& bgColor, const UColor& fgColor);
 
     CLASS_PROTOTYPE(GameSpyDialog);
 };

--- a/code/client/cl_uigamespy.h
+++ b/code/client/cl_uigamespy.h
@@ -1,0 +1,48 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+// cl_gamespy.h
+#ifndef __CL_GAMESPY_H__
+#define __CL_GAMESPY_H__
+
+#include "cl_ui.h"
+#include "keycodes.h"
+
+class GameSpyDialog : public UIFloatingWindow {
+private:
+    UIButton    *overlay;
+    UILabel     *label;
+    UIButton    *closeButton;
+
+protected:
+	void		FrameInitialized( void ) override;
+
+public:
+    GameSpyDialog();
+    ~GameSpyDialog();
+    void Create(UIWidget* parent, const UIRect2D& rect, const char* title, const UColor& bgColor, const UColor& fgColor);
+
+    CLASS_PROTOTYPE(GameSpyDialog);
+};
+
+void UI_LaunchGameSpy_f(void);
+#endif

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,7 +53,7 @@ This forces Windows to refresh display settings, which may restore brightness.
 <summary>I am using a custom map/mod, and I experience glitches that do not occur in the original game. What should I do?</summary>
 
 ### 1. Check game file precedences:
-As OpenMoHAA has MultiUser Support (on Windows, user game data is stored in `%APPDATA%\openmohaa`), custom files in this directory ovveride existing files in the game installation folder.
+As OpenMoHAA has MultiUser Support (on Windows, user game data is stored in `%APPDATA%\openmohaa`), custom files in this directory override existing files in the game installation folder.
 
 |Example|
 |-|
@@ -70,13 +70,57 @@ If changing the file precedences has no effect on the glitch you discovered, you
 <details>
 <summary>I cannot set my screen resolution in the Options/Video menu. How can I change it?</summary>
 
-### 1. Edit `omconfig.cfg`
+### Edit `omconfig.cfg`:
 
-If they do not exist, add the following cvars to your OpenMoHAA config file that is located in the user game data folder (on Windows,  `%APPDATA%\openmohaa\main` or `mainta` or `maintt` `\configs\omconfig.cfg`):
+If they do not exist, add the following console variables (cvars) to your `omconfig.cfg`[^1]
 
-> seta r_mode "-1"<br/>
-> seta r_customwidth "1920"<br/>
-> seta r_customheight "1080"
+```
+seta r_mode "-1"
+seta r_customwidth "1920"
+seta r_customheight "1080"
+```
+
+### or (alternatively) run the game with command line parameters:
+
+Launch your OpenMoHAA client with the following:
+
+```
++set r_mode -1 +set r_customwidth 1920 +set r_customheight 1080
+```
 
 Change the width and height accordingly.
+
 </details>
+
+---
+
+<details>
+<summary>Console does not show up in OpenMoHAA. How can I enable it?</summary>
+
+### 1. Check if console is enabled
+
+In the Options -> Advanced menu, make sure that the checkbox is checked (red "X") at the Console.
+Alternatively, check if the value is equal to 1 for the following cvar in `omconfig.cfg`[^1]:
+```
+seta ui_console "1"
+```
+
+### 2. Check Console keys cvar
+
+OpenMoHAA introduces a new cvar that stores the keys to open up console. Edit the following cvar in your `omconfig.cfg`[^1]:
+
+```
+seta cl_consoleKeys "~ ` 0x7e 0x60"
+```
+
+As you see the default variable above, you can add multiple keys (between the quotation marks, divided by spaces) to display/hide the console. 
+
+> bind ` "toggleconsole" is not to be used anymore.
+</details>
+
+
+---
+
+Footnotes:
+
+[^1]: omconfig.cfg is the OpenMoHAA configuration file that is located in the user game data folder (on Windows,  `%APPDATA%\openmohaa\main` or `mainta` or `maintt` `\configs\omconfig.cfg`)


### PR DESCRIPTION
resolves #127

Added a custom GameSpy service unavailable dialog that appears when users try to access GameSpy functionality. The dialog features a semi-transparent overlay background, a floating window with explanatory text about GameSpy's shutdown in 2014, and can be closed via a button, clicking the overlay, the X button, or pressing escape.

![CleanShot 2025-02-05 at 21 49 17](https://github.com/user-attachments/assets/bd87794d-dd09-4d4d-94e4-6610c5ebd14e)


https://github.com/user-attachments/assets/18895388-c723-4aa3-b384-cdce371d2b11



