### PR TITLE
feat: add click-outside-to-close for picker dialogs

### DIFF
--- a/code/client/cl_uifilepicker.cpp
+++ b/code/client/cl_uifilepicker.cpp
@@ -44,6 +44,15 @@ CLASS_DECLARATION(USignal, FilePickerClass, NULL) {
 
 FilePickerClass::FilePickerClass()
 {
+    overlay = new UIButton();
+    overlay->InitFrame(NULL,
+        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
+        0);
+    overlay->setBackgroundColor(UColor(0, 0, 0, 0), true);
+    overlay->AllowActivate(true);
+    overlay->Connect(this, W_Button_Pressed, W_Deactivated);
+    overlay->AddFlag(WF_ALWAYS_BOTTOM);
+
     window = new UIFloatingWindow();
     window->Create(
         NULL,
@@ -72,6 +81,11 @@ FilePickerClass::FilePickerClass()
 
 FilePickerClass::~FilePickerClass()
 {
+    if (overlay) {
+        delete overlay;
+        overlay = NULL;
+    }
+
     if (listbox) {
         delete listbox;
         listbox = NULL;

--- a/code/client/cl_uifilepicker.h
+++ b/code/client/cl_uifilepicker.h
@@ -26,6 +26,7 @@ class UIListCtrl;
 
 class FilePickerClass : public USignal
 {
+    UIButton         *overlay;
     UIFloatingWindow *window;
     UIListCtrl       *listbox;
     str               currentDirectory;

--- a/code/client/cl_uimpmappicker.cpp
+++ b/code/client/cl_uimpmappicker.cpp
@@ -48,6 +48,15 @@ CLASS_DECLARATION(USignal, MpMapPickerClass, NULL) {
 
 MpMapPickerClass::MpMapPickerClass()
 {
+    overlay = new UIButton();
+    overlay->InitFrame(NULL,
+        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
+        0);
+    overlay->setBackgroundColor(UColor(0, 0, 0, 0), true);
+    overlay->AllowActivate(true);
+    overlay->Connect(this, W_Button_Pressed, W_Deactivated);
+    overlay->AddFlag(WF_ALWAYS_BOTTOM);
+
     window = new UIFloatingWindow();
     window->Create(
         NULL,
@@ -79,6 +88,11 @@ MpMapPickerClass::MpMapPickerClass()
 
 MpMapPickerClass::~MpMapPickerClass()
 {
+    if (overlay) {
+        delete overlay;
+        overlay = NULL;
+    }
+
     if (listbox) {
         delete listbox;
         listbox = NULL;

--- a/code/client/cl_uimpmappicker.h
+++ b/code/client/cl_uimpmappicker.h
@@ -26,6 +26,7 @@ class UIFloatingWindow;
 
 class MpMapPickerClass : public USignal
 {
+    UIButton         *overlay;
     UIFloatingWindow *window;
     UIListCtrl       *listbox;
     str               currentDirectory;

--- a/code/client/cl_uiplayermodelpicker.cpp
+++ b/code/client/cl_uiplayermodelpicker.cpp
@@ -152,6 +152,15 @@ CLASS_DECLARATION(USignal, PlayerModelPickerClass, NULL) {
 
 PlayerModelPickerClass::PlayerModelPickerClass()
 {
+    overlay = new UIButton();
+    overlay->InitFrame(NULL,
+        UIRect2D(0, 0, uid.vidWidth, uid.vidHeight),
+        0);
+    overlay->setBackgroundColor(UColor(0, 0, 0, 0), true);
+    overlay->AllowActivate(true);
+    overlay->Connect(this, W_Button_Pressed, W_Deactivated);
+    overlay->AddFlag(WF_ALWAYS_BOTTOM);
+
     window = new UIFloatingWindow();
     window->Create(
         NULL,
@@ -185,6 +194,11 @@ PlayerModelPickerClass::PlayerModelPickerClass()
 
 PlayerModelPickerClass::~PlayerModelPickerClass()
 {
+    if (overlay) {
+        delete overlay;
+        overlay = NULL;
+    }
+
     if (listbox) {
         delete listbox;
         listbox = NULL;

--- a/code/client/cl_uiplayermodelpicker.h
+++ b/code/client/cl_uiplayermodelpicker.h
@@ -26,6 +26,7 @@ class UIFloatingWindow;
 
 class PlayerModelPickerClass : public USignal
 {
+    UIButton         *overlay;
     UIFloatingWindow *window;
     UIListCtrl       *listbox;
     str               currentDirectory;


### PR DESCRIPTION
resolve #226

Added click-to-close functionality for file selection dialogs by implementing a full-screen transparent overlay. When users click outside the FilePicker, PlayerModelPicker, or MultiPlayerMapPicker dialogs, they now automatically close, improving user experience and making the interface more intuitive.


https://github.com/user-attachments/assets/5189c00c-2a7a-4cd8-8dfa-d1013f103f76

