### PR TITLE
Implement multi-master queries and heartbeats

### DIFF
--- a/code/client/cl_uiserverlist.h
+++ b/code/client/cl_uiserverlist.h
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #pragma once
 
+#include "../gamespy/goaceng.h"
+
 class UIFAKKServerList : public UIListCtrl {
 protected:
 	// need a new struct instead of gamespy
@@ -47,6 +49,7 @@ protected:
 	void			MakeLANListing( Event *ev );
 	void			UpdateServer( Event *ev );
 	static int		ServerCompareFunction( const UIListCtrlItem *i1, const UIListCtrlItem *i2, int columnname );
+    static void     UpdateServerListCallBack(GServerList serverlist, int msg, void *instance, void *param1, void *param2);
 public:
 	UIFAKKServerList();
 

--- a/code/gamespy/cl_gamespy.c
+++ b/code/gamespy/cl_gamespy.c
@@ -25,12 +25,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cl_gamespy.h"
 #include "q_gamespy.h"
 
-const char *ServerListGetHost()
-{
-    return Com_GetMasterHost();
+unsigned int ServerListGetNumMasters() {
+    return Com_GetNumMasterEntries();
 }
 
-int ServerListGetMsPort()
+const char *ServerListGetHost(int index)
 {
-    return Com_GetMasterQueryPort();
+    return Com_GetMasterEntry(index)->host;
+}
+
+int ServerListGetMsPort(int index)
+{
+    return Com_GetMasterEntry(index)->queryport;
 }

--- a/code/gamespy/cl_gamespy.c
+++ b/code/gamespy/cl_gamespy.c
@@ -31,10 +31,16 @@ unsigned int ServerListGetNumMasters() {
 
 const char *ServerListGetHost(int index)
 {
-    return Com_GetMasterEntry(index)->host;
+    master_entry_t entry;
+    Com_GetMasterEntry(index, &entry);
+
+    return entry.host;
 }
 
 int ServerListGetMsPort(int index)
 {
-    return Com_GetMasterEntry(index)->queryport;
+    master_entry_t entry;
+    Com_GetMasterEntry(index, &entry);
+
+    return entry.queryport;
 }

--- a/code/gamespy/cl_gamespy.c
+++ b/code/gamespy/cl_gamespy.c
@@ -25,7 +25,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cl_gamespy.h"
 #include "q_gamespy.h"
 
-unsigned int ServerListGetNumMasters() {
+unsigned int ServerListGetNumMasters()
+{
     return Com_GetNumMasterEntries();
 }
 
@@ -44,3 +45,5 @@ int ServerListGetMsPort(int index)
 
     return entry.queryport;
 }
+
+void CL_RestartGamespy_f() {}

--- a/code/gamespy/cl_gamespy.h
+++ b/code/gamespy/cl_gamespy.h
@@ -23,3 +23,5 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // cl_gamespy.h -- Game-specific client GameSpy code
 
 #pragma once
+
+void CL_RestartGamespy_f();

--- a/code/gamespy/goaceng.h
+++ b/code/gamespy/goaceng.h
@@ -77,7 +77,7 @@ lanlist - we are waiting for replies from servers on the LAN
 querying - the servers on the list are being queried
 connecting (added in OPM) - socket is currently connecting to the master server
 */
-typedef enum {sl_idle, sl_listxfer, sl_lanlist, sl_querying, sl_connecting} GServerListState;
+typedef enum {sl_idle, sl_listxfer, sl_lanlist, sl_querying} GServerListState;
 
 /* Comparision types for the ServerListSort function
 int - assume the values are int and do an integer compare

--- a/code/gamespy/gserverlist.c
+++ b/code/gamespy/gserverlist.c
@@ -1052,7 +1052,12 @@ static GError ServerListQueryLoop(GServerList serverlist)
     if (serverlist->abortupdate || (serverlist->nextupdate >= ArrayLength(serverlist->servers) && scount == 0)) 
     { //we are done!!
         FreeUpdateList(serverlist);
-        if (!serverlist->abortupdate && serverlist->startslindex < ServerListGetNumMasters()) {
+        if (serverlist->abortupdate) {
+            ServerListModeChange(serverlist, sl_idle);
+            return 0;
+        }
+
+        if (serverlist->startslindex < ServerListGetNumMasters() || !ServerListFinishedList(serverlist)) {
             ServerListModeChange(serverlist, sl_listxfer);
         } else {
             // No more masters

--- a/code/gamespy/gserverlist.c
+++ b/code/gamespy/gserverlist.c
@@ -535,6 +535,8 @@ GError ServerListUpdate2(GServerList serverlist, gbool async, char *filter, GQue
     serverlist->async = async;
 
     if (async) {
+        // As it's asynchronous, set the state to transfering
+        ServerListModeChange(serverlist, sl_listxfer);
         return 0;
     }
 

--- a/code/gamespy/gserverlist.c
+++ b/code/gamespy/gserverlist.c
@@ -415,7 +415,9 @@ static GError SendListRequest(GServerList serverlist, GServerListSocket slsocket
     if (gsiSocketIsError(len) || len == 0)
         return GE_NOCONNECT;
 
-    ServerListModeChange(serverlist, sl_listxfer);
+    if (serverlist->state == sl_idle) {
+        ServerListModeChange(serverlist, sl_listxfer);
+    }
     return 0;
 }
 

--- a/code/gamespy/gserverlist.c
+++ b/code/gamespy/gserverlist.c
@@ -184,7 +184,10 @@ GServerList	ServerListNew(const char *gamename, const char *enginename, const ch
     list->encryptdata = 1;
     list->async = 0;
 
-    list->numslsockets = 2;
+    list->numslsockets = maxconcupdates / 4;
+    if (list->numslsockets < 1) {
+        list->numslsockets = 1;
+    }
     list->slsockets = (GServerListSocket)malloc(sizeof(struct GServerListSocketImplementation) * list->numslsockets);
     memset(list->slsockets, 0, sizeof(struct GServerListSocketImplementation) * list->numslsockets);
     list->startslindex = 0;

--- a/code/gamespy/gserverlist.c
+++ b/code/gamespy/gserverlist.c
@@ -530,7 +530,11 @@ GError ServerListUpdate2(GServerList serverlist, gbool async, char *filter, GQue
     serverlist->numservers = ServerListCount(serverlist);
     // Added in 2.0
     //serverlist->cryptinfo.offset = -1;
-    strncpy(serverlist->filter, filter, sizeof(serverlist->filter));
+    if (filter) {
+        strncpy(serverlist->filter, filter, sizeof(serverlist->filter));
+    } else {
+        serverlist->filter[0] = 0;
+    }
 
     serverlist->async = async;
 

--- a/code/gamespy/gserverlist.c
+++ b/code/gamespy/gserverlist.c
@@ -189,6 +189,8 @@ GServerList	ServerListNew(const char *gamename, const char *enginename, const ch
     list->numslsockets = maxconcupdates / 4;
     if (list->numslsockets < 1) {
         list->numslsockets = 1;
+    } else if (list->numslsockets > 2) {
+        list->numslsockets = 2;
     }
     list->slsockets = (GServerListSocket)malloc(sizeof(struct GServerListSocketImplementation) * list->numslsockets);
     memset(list->slsockets, 0, sizeof(struct GServerListSocketImplementation) * list->numslsockets);

--- a/code/gamespy/q_gamespy.c
+++ b/code/gamespy/q_gamespy.c
@@ -25,23 +25,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "q_gamespy.h"
 #include "q_shared.h"
 
-master_entry_t entries[16] =
-{
-    { "master.333networks.com", 28900, 27900 },
-    { "master.errorist.eu", 28900, 27900 }
+master_entry_t entries[16] = {
+    {"master.333networks.com",      28900, 27900},
+    {"master.errorist.eu",          28900, 27900},
+    {"master.noccer.de",            28900, 27900},
+    {"master-au.unrealarchive.org", 28900, 27900},
+    {"master.frag-net.com",         28900, 27900},
 };
 
-int num_entries = 1;
+int num_entries = 5;
 
-void Com_InitGameSpy()
+void Com_InitGameSpy() {}
+
+unsigned int Com_GetNumMasterEntries()
 {
-}
-
-unsigned int Com_GetNumMasterEntries() {
     return num_entries;
 }
 
-const master_entry_t *Com_GetMasterEntry(int index) {
+const master_entry_t *Com_GetMasterEntry(int index)
+{
     if (index >= num_entries) {
         return NULL;
     }

--- a/code/gamespy/q_gamespy.c
+++ b/code/gamespy/q_gamespy.c
@@ -23,45 +23,91 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #pragma once
 
 #include "q_gamespy.h"
-#include "q_shared.h"
+#include "../qcommon/q_shared.h"
+#include "../qcommon/qcommon.h"
 
-master_entry_t entries[16] = {
-    {"master.333networks.com",      28900, 27900},
-    {"master.errorist.eu",          28900, 27900},
-    {"master.noccer.de",            28900, 27900},
-    {"master-au.unrealarchive.org", 28900, 27900},
-    {"master.frag-net.com",         28900, 27900},
-};
+#define MAX_MASTERS 8
+#define MASTER_DEFAULT_MSPORT 28900
+#define MASTER_DEFAULT_HBPORT 27900
 
-int num_entries = 5;
+cvar_t *com_master_host[MAX_MASTERS];
+cvar_t *com_master_msport[MAX_MASTERS];
+cvar_t *com_master_hbport[MAX_MASTERS];
 
-void Com_InitGameSpy() {}
+master_entry_t entries[MAX_MASTERS];
+int num_entries = 0;
+
+static void CreateMasterVar(int index, const char *host, int msport, int hbport) {
+    com_master_host[index] = Cvar_Get(va("com_master%d_host", index), host, CVAR_INIT);
+    com_master_msport[index] = Cvar_Get(va("com_master%d_msport", index), va("%d", msport), CVAR_INIT);
+    com_master_hbport[index] = Cvar_Get(va("com_master%d_hbport", index), va("%d", hbport), CVAR_INIT);
+}
+
+void Com_InitGameSpy() {
+    int i;
+
+    //
+    // These entries come from the 333networks community and use the same software
+    // that emulate the GameSpy protocol -- see https://333networks.com/
+    // These masters are managed by different entities, they are independent and are syncing eachother.
+    //
+    CreateMasterVar(0, "master.333networks.com", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(1, "master.errorist.eu", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(2, "master.noccer.de", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(3, "master-au.unrealarchive.org", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(4, "master.frag-net.com", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+
+    for(i = 5; i < MAX_MASTERS; i++) {
+        CreateMasterVar(i, "", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    }
+
+    num_entries = 0;
+
+    //
+    // Find and insert valid entries
+    //
+    for(i = 0; i < MAX_MASTER_SERVERS; i++) {
+        master_entry_t *entry = &entries[num_entries];
+
+        if (com_master_host[i]->string && com_master_host[i]->string[0]) {
+            entry->host = com_master_host[i]->string;
+            entry->queryport = com_master_msport[i]->integer;
+            entry->hbport = com_master_hbport[i]->integer;
+            num_entries++;
+        }
+    }
+}
 
 unsigned int Com_GetNumMasterEntries()
 {
     return num_entries;
 }
 
-const master_entry_t *Com_GetMasterEntry(int index)
+void Com_GetMasterEntry(int index, master_entry_t* entry)
 {
     if (index >= num_entries) {
-        return NULL;
+        entry->host = NULL;
+        entry->hbport = 0;
+        entry->queryport = 0;
+        return;
     }
 
-    return &entries[index];
+    entry->host = com_master_host[index]->string;
+    entry->queryport = com_master_msport[index]->integer;
+    entry->hbport = com_master_hbport[index]->integer;
 }
 
 const char *Com_GetMasterHost()
 {
-    return entries[0].host;
+    return com_master_host[0]->string;
 }
 
 int Com_GetMasterQueryPort()
 {
-    return entries[0].queryport;
+    return com_master_msport[0]->integer;
 }
 
 int Com_GetMasterHeartbeatPort()
 {
-    return entries[0].hbport;
+    return com_master_hbport[0]->integer;
 }

--- a/code/gamespy/q_gamespy.c
+++ b/code/gamespy/q_gamespy.c
@@ -61,6 +61,8 @@ static qboolean ShouldRefreshMasters()
 
 static void CreateMasterVar(int index, const char *host, int msport, int hbport)
 {
+    assert(index < MAX_MASTERS);
+
     //
     // These variables should be modified for testing purposes only.
     // So prevent them to be saved in the configuration file.
@@ -76,6 +78,7 @@ static void CreateMasterVar(int index, const char *host, int msport, int hbport)
 
 qboolean Com_RefreshGameSpyMasters()
 {
+    int      msIndex = 0;
     int      i;
     qboolean shouldRestart;
 
@@ -86,14 +89,14 @@ qboolean Com_RefreshGameSpyMasters()
     // that emulate the GameSpy protocol -- see https://333networks.com/
     // They are managed by different entities, are independent and sync with eachother.
     //
-    CreateMasterVar(0, "master.333networks.com", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
-    CreateMasterVar(1, "master.errorist.eu", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
-    CreateMasterVar(2, "master.noccer.de", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
-    CreateMasterVar(3, "master-au.unrealarchive.org", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
-    CreateMasterVar(4, "master.frag-net.com", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(msIndex++, "master.333networks.com", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(msIndex++, "master.errorist.eu", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(msIndex++, "master.noccer.de", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(msIndex++, "master-au.unrealarchive.org", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    CreateMasterVar(msIndex++, "master.frag-net.com", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
 
-    for (i = 5; i < MAX_MASTERS; i++) {
-        CreateMasterVar(i, "", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
+    for (; msIndex < MAX_MASTERS; msIndex++) {
+        CreateMasterVar(msIndex, "", MASTER_DEFAULT_MSPORT, MASTER_DEFAULT_HBPORT);
     }
 
     num_entries = 0;

--- a/code/gamespy/q_gamespy.c
+++ b/code/gamespy/q_gamespy.c
@@ -23,22 +23,43 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #pragma once
 
 #include "q_gamespy.h"
+#include "q_shared.h"
+
+master_entry_t entries[16] =
+{
+    { "master.333networks.com", 28900, 27900 },
+    { "master.errorist.eu", 28900, 27900 }
+};
+
+int num_entries = 1;
 
 void Com_InitGameSpy()
 {
 }
 
+unsigned int Com_GetNumMasterEntries() {
+    return num_entries;
+}
+
+const master_entry_t *Com_GetMasterEntry(int index) {
+    if (index >= num_entries) {
+        return NULL;
+    }
+
+    return &entries[index];
+}
+
 const char *Com_GetMasterHost()
 {
-    return "master.333networks.com";
+    return entries[0].host;
 }
 
 int Com_GetMasterQueryPort()
 {
-    return 28900;
+    return entries[0].queryport;
 }
 
 int Com_GetMasterHeartbeatPort()
 {
-    return 27900;
+    return entries[0].hbport;
 }

--- a/code/gamespy/q_gamespy.h
+++ b/code/gamespy/q_gamespy.h
@@ -24,8 +24,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #pragma once
 
+typedef struct {
+    char host[128];
+    int queryport;
+    int hbport;
+} master_entry_t;
+
 void Com_InitGameSpy();
 
+unsigned int Com_GetNumMasterEntries();
+const master_entry_t *Com_GetMasterEntry(int index);
 const char *Com_GetMasterHost();
 int Com_GetMasterQueryPort();
 int Com_GetMasterHeartbeatPort();

--- a/code/gamespy/q_gamespy.h
+++ b/code/gamespy/q_gamespy.h
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #pragma once
 
+#include "../qcommon/q_shared.h"
+
 typedef struct {
     const char *host;
     int queryport;
@@ -31,6 +33,7 @@ typedef struct {
 } master_entry_t;
 
 void Com_InitGameSpy();
+qboolean Com_RefreshGameSpyMasters();
 
 unsigned int Com_GetNumMasterEntries();
 void Com_GetMasterEntry(int index, master_entry_t* entry);

--- a/code/gamespy/q_gamespy.h
+++ b/code/gamespy/q_gamespy.h
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #pragma once
 
 typedef struct {
-    char host[128];
+    const char *host;
     int queryport;
     int hbport;
 } master_entry_t;
@@ -33,7 +33,7 @@ typedef struct {
 void Com_InitGameSpy();
 
 unsigned int Com_GetNumMasterEntries();
-const master_entry_t *Com_GetMasterEntry(int index);
+void Com_GetMasterEntry(int index, master_entry_t* entry);
 const char *Com_GetMasterHost();
 int Com_GetMasterQueryPort();
 int Com_GetMasterHeartbeatPort();

--- a/code/gamespy/sv_gamespy.c
+++ b/code/gamespy/sv_gamespy.c
@@ -510,10 +510,16 @@ unsigned int qr_get_num_masters()
 
 const char *qr_get_master_host(int index)
 {
-    return Com_GetMasterEntry(index)->host;
+    master_entry_t entry;
+    Com_GetMasterEntry(index, &entry);
+
+    return entry.host;
 }
 
 int qr_get_master_port(int index)
 {
-    return Com_GetMasterEntry(index)->hbport;
+    master_entry_t entry;
+    Com_GetMasterEntry(index, &entry);
+
+    return entry.hbport;
 }

--- a/code/gamespy/sv_gamespy.c
+++ b/code/gamespy/sv_gamespy.c
@@ -503,12 +503,17 @@ void SV_GamespyAuthorize(netadr_t from, const char *response)
     }
 }
 
-const char *qr_get_master_host()
+unsigned int qr_get_num_masters()
 {
-    return Com_GetMasterHost();
+    return Com_GetNumMasterEntries();
 }
 
-int qr_get_master_port()
+const char *qr_get_master_host(int index)
 {
-    return Com_GetMasterHeartbeatPort();
+    return Com_GetMasterEntry(index)->host;
+}
+
+int qr_get_master_port(int index)
+{
+    return Com_GetMasterEntry(index)->hbport;
 }

--- a/code/gamespy/sv_gamespy.c
+++ b/code/gamespy/sv_gamespy.c
@@ -34,7 +34,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 static char        gamemode[128];
 static qboolean    gcdInitialized = qfalse;
 static qboolean    gcdValid       = qfalse;
+static qboolean    gsRunning      = qfalse;
 extern GSIACResult __GSIACResult;
+
+cvar_t *net_ip           = NULL;
+cvar_t *net_gamespy_port = NULL;
 
 static const char *SECRET_GS_KEYS[] =
 {
@@ -255,7 +259,7 @@ static void players_callback(char *outbuf, int maxlen, void *userdata)
             index,
             cl->ping
         );
-        
+
         if (currlen + infolen < maxlen) {
             strcat(outbuf, infostring);
             currlen += infolen;
@@ -302,6 +306,12 @@ void SV_ShutdownGamespy()
         return;
     }
 
+    if (!gsRunning) {
+        // Added in OPM
+        //  Gamespy is not running
+        return;
+    }
+
     strcpy(gamemode, "exiting");
 
     if (gcdInitialized) {
@@ -311,12 +321,12 @@ void SV_ShutdownGamespy()
 
     qr_send_statechanged(NULL);
     qr_shutdown(NULL);
+
+    gsRunning = qfalse;
 }
 
 qboolean SV_InitGamespy()
 {
-    cvar_t     *net_ip;
-    cvar_t     *net_gamespy_port;
     char        secret_key[9];
     const char *secret_gs_key;
     const char *gs_game_name;
@@ -377,6 +387,8 @@ qboolean SV_InitGamespy()
 
         gcdInitialized = qtrue;
     }
+
+    gsRunning = qtrue;
 
     return qtrue;
 }
@@ -500,6 +512,40 @@ void SV_GamespyAuthorize(netadr_t from, const char *response)
         break;
     default:
         break;
+    }
+}
+
+void SV_RestartGamespy()
+{
+    if (gsRunning) {
+        //
+        // Reinitialize Gamespy
+        //
+        SV_ShutdownGamespy();
+        SV_InitGamespy();
+    }
+}
+
+void SV_RestartGamespy_f()
+{
+    SV_RestartGamespy();
+}
+
+void SV_TryRestartGamespy()
+{
+    if (Com_RefreshGameSpyMasters()) {
+        SV_RestartGamespy();
+        return;
+    }
+
+    if (net_gamespy_port && net_gamespy_port->latchedString) {
+        SV_RestartGamespy();
+        return;
+    }
+
+    if (sv_gamespy && sv_gamespy->latchedString) {
+        SV_RestartGamespy();
+        return;
     }
 }
 

--- a/code/gamespy/sv_gamespy.h
+++ b/code/gamespy/sv_gamespy.h
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #pragma once
 
+#include "q_gamespy.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,6 +39,11 @@ extern const char* GS_GetCurrentGameName();
 
 void SV_CreateGamespyChallenge(char* challenge);
 void SV_GamespyAuthorize(netadr_t from, const char* response);
+void SV_GamespyHeartbeat();
+void SV_ProcessGamespyQueries();
+qboolean SV_InitGamespy();
+void SV_ShutdownGamespy();
+void SV_RestartGamespy();
 
 #ifdef __cplusplus
 }

--- a/code/gamespy/sv_gamespy.h
+++ b/code/gamespy/sv_gamespy.h
@@ -44,6 +44,8 @@ void SV_ProcessGamespyQueries();
 qboolean SV_InitGamespy();
 void SV_ShutdownGamespy();
 void SV_RestartGamespy();
+void SV_RestartGamespy_f();
+void SV_TryRestartGamespy();
 
 #ifdef __cplusplus
 }

--- a/code/gamespy/sv_gqueryreporting.c
+++ b/code/gamespy/sv_gqueryreporting.c
@@ -448,6 +448,14 @@ void qr_shutdown(qr_t qrec)
     {
         gsifree(qrec);
     }
+    
+    if (MasterList) {
+        gsifree(MasterList);
+        MasterList = NULL;
+    }
+
+    MasterCount = 0;
+
     SocketShutDown();
 }
 
@@ -479,9 +487,11 @@ static int do_connect_multi()
     MasterMaxCount = qr_get_num_masters();
     if (MasterList) {
         gsifree(MasterList);
+        MasterList = NULL;
     }
 
     MasterList = gsimalloc(sizeof(struct sockaddr_in) * MasterMaxCount);
+    MasterCount = 0;
 
     for(i = 0; i < MasterMaxCount; i++) {
         struct sockaddr_in hbaddr;

--- a/code/gamespy/sv_gqueryreporting.c
+++ b/code/gamespy/sv_gqueryreporting.c
@@ -495,9 +495,10 @@ static int do_connect_multi()
 
     for(i = 0; i < MasterMaxCount; i++) {
         struct sockaddr_in hbaddr;
-        get_sockaddrin(qr_get_master_host(i), qr_get_master_port(i), &hbaddr, NULL);
-
-        add_master(&hbaddr);
+        if (get_sockaddrin(qr_get_master_host(i), qr_get_master_port(i), &hbaddr, NULL)) {
+            // Valid, add it
+            add_master(&hbaddr);
+        }
     }
 
     return 0;

--- a/code/gamespy/sv_gqueryreporting.c
+++ b/code/gamespy/sv_gqueryreporting.c
@@ -163,9 +163,11 @@ struct qr_implementation_s static_rec = {INVALID_SOCKET, INVALID_SOCKET};
 static qr_t current_rec = &static_rec;
 //char qr_hostname[64] = MASTER_ADDR;
 
-static struct sockaddr_in MasterList[8];
+//static struct sockaddr_in MasterList[8];
+static struct sockaddr_in *MasterList = NULL;
 static char keyvalue[8192];
 static int MasterCount;
+static int MasterMaxCount;
 
 /********
 PROTOTYPES
@@ -173,6 +175,7 @@ PROTOTYPES
 static void send_heartbeat(qr_t qrec, int statechanged);
 static void qr_parse_query(qr_t qrec, char* query, int len, struct sockaddr* sender);
 static int do_connect(SOCKET sock, char* addr, int port, struct sockaddr_in* hbaddr);
+static int do_connect_multi();
 void qr_check_queries(qr_t qrec);
 void qr_check_send_heartbeat(qr_t qrec);
 
@@ -270,7 +273,7 @@ int qr_init(qr_t* qrec,
         qrec = &current_rec;
     }
 
-    return do_connect(hbsock, MASTER_ADDR, MASTER_PORT, &(*qrec)->hbaddr);
+    return do_connect_multi();
 }
 
 void init_qrec(qr_t* qrec,
@@ -339,7 +342,7 @@ int qr_init_socket(qr_t* qrec,
               qr_players_callback,
               userdata);
 
-    return do_connect(s, MASTER_ADDR, MASTER_PORT, &(*qrec)->hbaddr);
+    return do_connect_multi();
 }
 
 /* qr_process_queries: Processes any waiting queries, and sends a
@@ -466,6 +469,27 @@ static int do_connect(SOCKET sock, char* addr, int port, struct sockaddr_in* hba
     get_sockaddrin(addr, port, hbaddr, NULL);
     add_master(hbaddr);
 #endif
+    return 0;
+}
+
+static int do_connect_multi()
+{
+    int i;
+
+    MasterMaxCount = qr_get_num_masters();
+    if (MasterList) {
+        gsifree(MasterList);
+    }
+
+    MasterList = gsimalloc(sizeof(struct sockaddr_in) * MasterMaxCount);
+
+    for(i = 0; i < MasterMaxCount; i++) {
+        struct sockaddr_in hbaddr;
+        get_sockaddrin(qr_get_master_host(i), qr_get_master_port(i), &hbaddr, NULL);
+
+        add_master(&hbaddr);
+    }
+
     return 0;
 }
 
@@ -817,7 +841,7 @@ void add_master(struct sockaddr_in* addr)
             return;
         }
     }
-    if (i == 8) {
+    if (i == MasterMaxCount) {
         return;
     } else {
         MasterList[i] = *addr;

--- a/code/gamespy/sv_gqueryreporting.h
+++ b/code/gamespy/sv_gqueryreporting.h
@@ -65,9 +65,9 @@ as the base port. Generally there is no reason to modify this value.
 /********
 DEFINES
 ********/
-#define MASTER_PORT     qr_get_master_port()
+#define MASTER_PORT     qr_get_master_port(0)
 //#define MASTER_ADDR     "master." GSI_DOMAIN_NAME
-#define MASTER_ADDR     qr_get_master_host()
+#define MASTER_ADDR     qr_get_master_host(0)
 #define FIRST_HB_TIME   30000  /* 30 sec */
 #define HB_TIME         300000 /* 5 minutes */
 #define MAX_FIRST_COUNT 10     /* 10 tries = 5 minutes */

--- a/code/gamespy/sv_gqueryreporting.h
+++ b/code/gamespy/sv_gqueryreporting.h
@@ -86,8 +86,9 @@ extern char qr_hostname[64];
  * 
  * @return const char* The full master server address
  */
-extern const char *qr_get_master_host();
-extern int qr_get_master_port();
+extern unsigned int qr_get_num_masters();
+extern const char *qr_get_master_host(int index);
+extern int qr_get_master_port(int index);
 
 /********
 qr_querycallback_t

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -1996,6 +1996,8 @@ void Com_Init( char *commandLine ) {
 
 	RecoverLostAutodialData();
 
+    // Added in OPM
+    //  Initialize GameSpy related stuff
     Com_InitGameSpy();
 
 	iEnd = Sys_Milliseconds();

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -633,14 +633,6 @@ void SV_NET_UpdateClientNetProfileInfo(netprofclient_t* netprofile, int rate);
 void SV_NET_UpdateAllNetProfileInfo();
 void SV_NET_CalcTotalNetProfile(netprofclient_t* netprofile, qboolean server);
 
-//
-// sv_gamespy.c
-//
-void SV_GamespyHeartbeat();
-void SV_ProcessGamespyQueries();
-qboolean SV_InitGamespy();
-void SV_ShutdownGamespy();
-
 #ifdef __cplusplus
 }
 #endif

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "../client/client.h"
 #include "../qcommon/tiki.h"
 #include "../qcommon/bg_compat.h"
+#include "../gamespy/sv_gamespy.h"
 
 static char last_mapname[ MAX_QPATH ];
 static int g_iSvsTimeFixupCount;


### PR DESCRIPTION
This improves multiplayer availability by implementing support for using multiple masters:
- The server sends an heartbeat to all masters at once
- Client can query up to 4 masters in parallel depending on the rate. Very low rate (5000 bps) will query 1 master. The client first fetches servers from masters, then it queries all servers, and so on.
