### PR TITLE
Use the hardware cursor in windowed mode

### DIFF
--- a/code/client/cl_input.cpp
+++ b/code/client/cl_input.cpp
@@ -473,6 +473,28 @@ void CL_JoystickEvent( int axis, int value, int time ) {
 
 /*
 =================
+CL_UpdateMouse
+
+Added in OPM
+Update mouse position with absolute position (relative to the window)
+when the UI catcher is active.
+=================
+*/
+void CL_UpdateMouse() {
+    if (!(Key_GetCatcher() & KEYCATCH_UI)) {
+        return;
+    }
+
+    if (com_unfocused->integer) {
+        // Ignore updates when unfocused
+        return;
+    }
+
+    IN_GetMousePosition(&cl.mousex, &cl.mousey);
+}
+
+/*
+=================
 CL_JoystickMove
 =================
 */

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -2792,6 +2792,9 @@ void CL_Frame ( int msec ) {
 
 	L_ProcessPendingEvents();
 
+    // Added in OPM
+    CL_UpdateMouse();
+
 	// update the screen
 	SCR_UpdateScreen();
 

--- a/code/client/cl_ui.cpp
+++ b/code/client/cl_ui.cpp
@@ -3794,6 +3794,8 @@ void CL_FillUIImports(void)
 
     uii.GetRefSequence = CL_GetRefSequence;
     uii.IsRendererLoaded = CL_IsRendererLoaded;
+    uii.Rend_LoadRawImage = re.LoadRawImage;
+    uii.Rend_FreeRawImage = re.FreeRawImage;
 }
 
 /*

--- a/code/client/cl_uiserverlist.cpp
+++ b/code/client/cl_uiserverlist.cpp
@@ -619,6 +619,8 @@ void UIFAKKServerList::RefreshServerList(Event *ev)
     }
 
     m_bUpdatingList = true;
+
+    RefreshStatus();
 }
 
 void UIFAKKServerList::RefreshLANServerList(Event *ev)

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -582,6 +582,7 @@ extern	qboolean	in_guimouse;
 void IN_ToggleMouse( void );
 void IN_MouseOn( void );
 void IN_MouseOff( void );
+void CL_UpdateMouse();
 
 void CL_InitInput (void);
 void CL_ShutdownInput(void);

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1285,6 +1285,7 @@ void IN_GetMousePosition(int *x, int *y);
 typedef void (*pCursorFree)(byte *pic);
 qboolean IN_SetCursorFromImage(const byte *pic, int width, int height, pCursorFree cursorFreeFn);
 void IN_FreeCursor();
+qboolean IN_IsCursorActive();
 
 void Com_Pause();
 void Com_Unpause();

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1280,6 +1280,7 @@ void IN_Init(void *windowData);
 void IN_Frame(void);
 void IN_Shutdown(void);
 void IN_Restart(void);
+void IN_GetMousePosition(int *x, int *y);
 
 void Com_Pause();
 void Com_Unpause();

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1282,6 +1282,10 @@ void IN_Shutdown(void);
 void IN_Restart(void);
 void IN_GetMousePosition(int *x, int *y);
 
+typedef void (*pCursorFree)(byte *pic);
+qboolean IN_SetCursorFromImage(const byte *pic, int width, int height, pCursorFree cursorFreeFn);
+void IN_FreeCursor();
+
 void Com_Pause();
 void Com_Unpause();
 void Com_FakePause();

--- a/code/renderercommon/tr_public.h
+++ b/code/renderercommon/tr_public.h
@@ -175,6 +175,9 @@ typedef struct {
 
 	qboolean (*ImageExists)(const char* name);
 	int (*CountTextureMemory)();
+
+    qboolean (*LoadRawImage)(const char *name, byte **pic, int *width, int *height);
+    void (*FreeRawImage)(byte *pic);
 } refexport_t;
 
 //

--- a/code/renderergl1/tr_image.c
+++ b/code/renderergl1/tr_image.c
@@ -3264,3 +3264,32 @@ void	R_SkinList_f( void ) {
 	ri.Printf (PRINT_ALL, "------------------\n");
 }
 
+/*
+===============
+R_LoadRawImage
+===============
+*/
+qboolean R_LoadRawImage(const char *name, byte **pic, int *width, int *height)
+{
+    qboolean hasAlpha;
+    int glCompressMode;
+    int numMipmaps;
+    int piMipmapsAvailable;
+
+    R_LoadImage(name, pic, width, height, &hasAlpha, &glCompressMode, &numMipmaps, &piMipmapsAvailable);
+
+    if (!*pic) {
+        return qfalse;
+    }
+
+    return qtrue;
+}
+
+/*
+===============
+R_FreeRawImage
+===============
+*/
+void R_FreeRawImage(byte *pic) {
+    ri.Free(pic);
+}

--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -1964,5 +1964,8 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
 	re.ImageExists = R_ImageExists;
 	re.CountTextureMemory = R_CountTextureMemory;
 
+    re.LoadRawImage = R_LoadRawImage;
+    re.FreeRawImage = R_FreeRawImage;
+
 	return &re;
 }

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -1799,6 +1799,8 @@ image_t* R_CreateImageOld(
 
 qboolean R_ImageExists(const char* name);
 int R_CountTextureMemory();
+qboolean R_LoadRawImage(const char *name, byte **pic, int *width, int *height);
+void R_FreeRawImage(byte *pic);
 
 qboolean	R_GetModeInfo( int *width, int *height, float *windowAspect, int mode );
 

--- a/code/renderergl2/tr_image.c
+++ b/code/renderergl2/tr_image.c
@@ -3525,3 +3525,34 @@ int R_CountTextureMemory() {
 
     return total_bytes;
 }
+
+
+/*
+===============
+R_LoadRawImage
+===============
+*/
+qboolean R_LoadRawImage(const char *name, byte **pic, int *width, int *height)
+{
+    qboolean hasAlpha;
+    int glCompressMode;
+    int numMipmaps;
+    int piMipmapsAvailable;
+
+    R_LoadImage(name, pic, width, height, &glCompressMode, &numMipmaps);
+
+    if (!*pic) {
+        return qfalse;
+    }
+
+    return qtrue;
+}
+
+/*
+===============
+R_FreeRawImage
+===============
+*/
+void R_FreeRawImage(byte *pic) {
+    ri.Free(pic);
+}

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -2072,5 +2072,8 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
 	re.ImageExists = R_ImageExists;
 	re.CountTextureMemory = R_CountTextureMemory;
 
+    re.LoadRawImage = R_LoadRawImage;
+    re.FreeRawImage = R_FreeRawImage;
+
 	return &re;
 }

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -2666,6 +2666,8 @@ int R_DistanceCullLocalPointAndRadius(float fDist, const vec3_t pt, float radius
 int R_DistanceCullPointAndRadius(float fDist, const vec3_t pt, float radius);
 qboolean R_ImageExists(const char* name);
 int R_CountTextureMemory();
+qboolean R_LoadRawImage(const char *name, byte **pic, int *width, int *height);
+void R_FreeRawImage(byte *pic);
 
 //
 // tr_bsp.c

--- a/code/sdl/CMakeLists.txt
+++ b/code/sdl/CMakeLists.txt
@@ -4,6 +4,7 @@ project(omohsdl)
 
 set(SOURCES_SDL_CLIENT
 "./sdl_input.c"
+"./sdl_mouse.c"
 )
 
 set(SOURCES_SDL_GL

--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1221,7 +1221,7 @@ void IN_Frame( void )
 	// update isFullscreen since it might of changed since the last vid_restart
 	cls.glconfig.isFullscreen = Cvar_VariableIntegerValue( "r_fullscreen" ) != 0;
 
-	if( !cls.glconfig.isFullscreen && ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) )
+	if( !cls.glconfig.isFullscreen && ( Key_GetCatcher( ) & (KEYCATCH_CONSOLE|KEYCATCH_UI) ) )
 	{
 		// Console is down in windowed mode
 		IN_DeactivateMouse( cls.glconfig.isFullscreen );

--- a/code/sdl/sdl_input.c
+++ b/code/sdl/sdl_input.c
@@ -1216,7 +1216,7 @@ void IN_Frame( void )
 	IN_JoyMove( );
 
 	// If not DISCONNECTED (main menu) or ACTIVE (in game), we're loading
-	loading = (clc.state == CA_LOADING || clc.state == CA_PRIMED);
+	loading = ( clc.state != CA_DISCONNECTED && clc.state != CA_ACTIVE );
 
 	// update isFullscreen since it might of changed since the last vid_restart
 	cls.glconfig.isFullscreen = Cvar_VariableIntegerValue( "r_fullscreen" ) != 0;

--- a/code/sdl/sdl_mouse.c
+++ b/code/sdl/sdl_mouse.c
@@ -63,3 +63,8 @@ void IN_FreeCursor() {
         cursor_image_data = NULL;
     }
 }
+
+qboolean IN_IsCursorActive()
+{
+    return SDL_GetGrabbedWindow() != NULL;
+}

--- a/code/sdl/sdl_mouse.c
+++ b/code/sdl/sdl_mouse.c
@@ -28,6 +28,38 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "../qcommon/qcommon.h"
 
+static SDL_Cursor *cursor = NULL;
+static SDL_Surface *cursor_surface = NULL;
+static byte *cursor_image_data = NULL;
+static pCursorFree cursor_free = NULL;
+
 void IN_GetMousePosition(int *x, int *y) {
     SDL_GetMouseState(x, y);
+}
+
+qboolean IN_SetCursorFromImage(const byte *pic, int width, int height, pCursorFree cursorFreeFn) {
+    IN_FreeCursor();
+
+    cursor_surface = SDL_CreateRGBSurfaceWithFormatFrom(pic, width, height, 32, 4 * width, SDL_PIXELFORMAT_ABGR8888);
+    if (!cursor_surface) {
+        return qfalse;
+    }
+
+    cursor = SDL_CreateColorCursor(cursor_surface, 0, 0);
+    SDL_SetCursor(cursor);
+
+    return qtrue;
+}
+
+void IN_FreeCursor() {
+    if (cursor) {
+        SDL_FreeCursor(cursor);
+    }
+    if (cursor_surface) {
+        SDL_FreeSurface(cursor_surface);
+    }
+    if (cursor_image_data) {
+        cursor_free(cursor_image_data);
+        cursor_image_data = NULL;
+    }
 }

--- a/code/sdl/sdl_mouse.c
+++ b/code/sdl/sdl_mouse.c
@@ -1,0 +1,33 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+#ifdef USE_LOCAL_HEADERS
+#    include "SDL.h"
+#else
+#    include <SDL.h>
+#endif
+
+#include "../qcommon/qcommon.h"
+
+void IN_GetMousePosition(int *x, int *y) {
+    SDL_GetMouseState(x, y);
+}

--- a/code/uilib/ui_public.h
+++ b/code/uilib/ui_public.h
@@ -132,6 +132,8 @@ typedef struct uiimport_s {
 	//
 	int (*GetRefSequence)(void);
 	qboolean (*IsRendererLoaded)(void);
+    qboolean (*Rend_LoadRawImage)(const char *name, byte **pic, int *width, int *height);
+    void (*Rend_FreeRawImage)(byte *pic);
 } uiimport_t;
 
 #if 1

--- a/code/uilib/uiwinman.cpp
+++ b/code/uilib/uiwinman.cpp
@@ -258,11 +258,16 @@ void UIWindowManager::UpdateViews(void)
     if (m_cursor && m_showcursor && uid.uiHasMouse) {
         vec4_t col;
 
-        VectorSet4(col, 1, 1, 1, 1);
         set2D();
-        uii.Rend_SetColor(col);
 
-        uii.Rend_DrawPicStretched(uid.mouseX, uid.mouseY, 0, 0, 0, 0, 1, 1, m_cursor->GetMaterial());
+        // Added in OPM
+        //  Don't draw the mouse if the OS cursor is enabled
+        if (!(Key_GetCatcher() | KEYCATCH_UI)) {
+            VectorSet4(col, 1, 1, 1, 1);
+            uii.Rend_SetColor(col);
+
+            uii.Rend_DrawPicStretched(uid.mouseX, uid.mouseY, 0, 0, 0, 0, 1, 1, m_cursor->GetMaterial());
+        }
 
         m_font->setColor(UWhite);
 

--- a/code/uilib/uiwinman.h
+++ b/code/uilib/uiwinman.h
@@ -88,6 +88,10 @@ public:
     void              DeactiveFloatingWindows(void);
     bool              DialogExists(void);
     void              RemoveAllDialogBoxes(void);
+
+private:
+    // Added in OPM
+    void refreshCursor();
 };
 
 extern Event W_MouseExited;


### PR DESCRIPTION
In windowed mode, the mouse is no longer grabbed when one of the UI/console catcher is active. When a UI menu is active, the system's hardware cursor is shown, using the game's custom cursor texture, instead of simulating and rendering the cursor in-game.
The mouse can be quickly released when opening the console or a menu, making it easier to debug and troubleshoot, especially in windowed mode or when running the game on a remote system.
