### PR TITLE
Rework the version string

### DIFF
--- a/code/client/cl_instantAction.cpp
+++ b/code/client/cl_instantAction.cpp
@@ -262,7 +262,7 @@ int UIInstantAction::GetServerIndex(int maxPing, int gameType)
                 }
             }
         } else {
-            if (fabs(fGameVer - com_target_version->value) > 0.1f) {
+            if (fabs(fGameVer - com_target_shortversion->value) > 0.1f) {
                 continue;
             }
         }
@@ -429,13 +429,13 @@ void UIInstantAction::Connect(Event *ev)
             }
         }
     } else {
-        if (fabs(fGameVer - com_target_version->value) > 0.1f) {
+        if (fabs(fGameVer - com_target_shortversion->value) > 0.1f) {
             bDiffVersion = true;
         }
     }
 
     if (bDiffVersion) {
-        if (fGameVer - com_target_version->value > 0) {
+        if (fGameVer - com_target_shortversion->value > 0) {
             // Older version
             UI_SetReturnMenuToCurrent();
             Cvar_Set("com_errormessage", va("Server is version %s, you are using %s", gameVer, "2.40"));

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -2043,7 +2043,7 @@ wombat: sending conect here: an example connect string from MOHAA looks like thi
 			Info_SetValueForKey(info, "protocol", va("%i", com_protocol->integer));
 		Info_SetValueForKey( info, "qport", va("%i", port ) );
 		Info_SetValueForKey(info, "challenge", va("%i", clc.challenge));
-		Info_SetValueForKey(info, "version", com_target_version->string);
+		Info_SetValueForKey(info, "version", com_target_shortversion->string);
 		if (com_target_game->integer == target_game_e::TG_MOHTT) {
 			// only send if maintt is loaded
 			Info_SetValueForKey(info, "clientType", "Breakthrough");
@@ -2415,7 +2415,7 @@ void CL_ConnectionlessPacket( netadr_t from, msg_t *msg ) {
 
     if (!Q_stricmp(c, "wrongver")) {
         reason = MSG_ReadString(msg);
-        Cvar_Set("com_errorMessage", va("Server is version %s, you are using %s, from base '%s'", reason, com_target_version->string, Cvar_VariableString("fs_basegame")));
+        Cvar_Set("com_errorMessage", va("Server is version %s, you are using %s, from base '%s'", reason, com_target_shortversion->string, Cvar_VariableString("fs_basegame")));
         CL_Disconnect_f();
         UI_ForceMenuOff(qtrue);
         UI_PushMenu("errormessage");
@@ -3921,7 +3921,7 @@ void CL_ServerInfoPacket( netadr_t from, msg_t *msg ) {
 				}
 			}
 		} else {
-			if (fabs(atof(pszVersion) - com_target_version->value) > 0.1f) {
+			if (fabs(atof(pszVersion) - com_target_shortversion->value) > 0.1f) {
 				return;
 			}
 		}

--- a/code/client/cl_ui.cpp
+++ b/code/client/cl_ui.cpp
@@ -5301,7 +5301,7 @@ void CL_InitializeUI(void)
 
     // New since mohta
     // Version number
-    Cvar_Set("game_version", va("v%s", com_target_version->string));
+    Cvar_Set("game_version", va("v%s", com_target_shortversion->string));
 
     // Add all commands
     Cmd_AddCommand("pushmenu", UI_PushMenu_f);

--- a/code/client/cl_uiserverlist.cpp
+++ b/code/client/cl_uiserverlist.cpp
@@ -391,7 +391,7 @@ void UIFAKKServerList::ConnectServer(Event *ev)
     pItem = static_cast<const FAKKServerListItem *>(GetItem(getCurrentItem()));
     if (pItem->IsDifferentVersion()) {
         const char *message;
-        float       neededVersion = com_target_version->value;
+        float       neededVersion = com_target_shortversion->value;
         float       serverVersion = atof(pItem->GetListItemVersion().c_str());
 
         // Tolerate patch version
@@ -401,7 +401,7 @@ void UIFAKKServerList::ConnectServer(Event *ev)
             message =
                 va("Server is version %s, you are targeting %s",
                    pItem->GetListItemVersion().c_str(),
-                   com_target_version->string);
+                   com_target_shortversion->string);
             Cvar_Set("com_errormessage", message);
 
             UI_PushMenu("wrongversion");
@@ -409,7 +409,7 @@ void UIFAKKServerList::ConnectServer(Event *ev)
             message =
                 va("Can not connect to v%s server, you are targeting v%s",
                    pItem->GetListItemVersion().c_str(),
-                   com_target_version->string);
+                   com_target_shortversion->string);
 
             Cvar_Set("dm_serverstatus", message);
         }
@@ -1140,7 +1140,7 @@ void UIFAKKServerList::UpdateServerListCallBack(
                 }
             }
         } else {
-            if (fabs(fGameVer - com_target_version->value) > 0.1f) {
+            if (fabs(fGameVer - com_target_shortversion->value) > 0.1f) {
                 bDiffVersion = true;
             }
         }

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -126,9 +126,13 @@ cvar_t  *con_autochat;
 #endif
 
 cvar_t	*precache;
+
 cvar_t	*com_target_game;
+cvar_t	*com_target_shortversion;
 cvar_t	*com_target_version;
+cvar_t	*com_target_extension;
 cvar_t	*com_target_demo;
+
 cvar_t	*com_updatecheck_enabled;
 cvar_t	*com_updatecheck_interval;
 
@@ -1759,7 +1763,9 @@ void Com_Init( char *commandLine ) {
 
 	com_target_game = Cvar_Get("com_target_game", "0", CVAR_INIT|CVAR_PROTECTED);
 	com_target_demo = Cvar_Get("com_target_demo", "0", CVAR_INIT|CVAR_PROTECTED);
-	com_target_version = Cvar_Get("com_target_version", "0.00", CVAR_ROM);
+	com_target_shortversion = Cvar_Get("com_target_shortversion", "0.00", CVAR_ROM);
+	com_target_version = Cvar_Get("com_target_version", "", CVAR_ROM);
+	com_target_extension = Cvar_Get("com_target_extension", "", CVAR_ROM);
 	com_standalone = Cvar_Get("com_standalone", "0", CVAR_ROM);
 	com_basegame = Cvar_Get("com_basegame", BASEGAME, CVAR_INIT);
 	com_homepath = Cvar_Get("com_homepath", "", CVAR_INIT|CVAR_PROTECTED);
@@ -1920,8 +1926,11 @@ void Com_Init( char *commandLine ) {
 		}
 	}
 
-	s = va( "%s %s (Medal of Honor: %s %s) %s %s", PRODUCT_NAME, PRODUCT_VERSION_FULL, Cvar_VariableString("com_target_extension"), Cvar_VariableString("com_target_version"), PLATFORM_STRING, PRODUCT_VERSION_DATE);
-	com_version = Cvar_Get( "version", s, CVAR_ROM | CVAR_SERVERINFO );
+    // Make the original game version appear first for backward compatibility.
+    // => Some software rely on the beginning of the string starting with "Medal of Honor [...]".
+    //    There are mods that also check for this.
+	s = va( "%s (%s %s) %s %s", com_target_version->string, PRODUCT_NAME, PRODUCT_VERSION_FULL, PLATFORM_STRING, PRODUCT_VERSION_DATE);
+    com_version = Cvar_Get( "version", s, CVAR_ROM | CVAR_SERVERINFO );
 	com_gamename = Cvar_Get("com_gamename", "", CVAR_SERVERINFO | CVAR_INIT | CVAR_USERINFO | CVAR_SERVERINFO);
 	com_shortversion = Cvar_Get( "shortversion", PRODUCT_VERSION, CVAR_ROM | CVAR_USERINFO | CVAR_SERVERINFO );
 	com_protocol = Cvar_Get("com_protocol", va("%i", PROTOCOL_VERSION), CVAR_INIT);
@@ -3134,8 +3143,9 @@ void Com_InitTargetGameWithType(target_game_e target_game, qboolean bIsDemo)
 			Cvar_Set("com_legacyprotocol", va("%i", PROTOCOL_MOH_DEMO));
         }
 		protocol_version_demo = protocol_version_full = PROTOCOL_MOH;
-		Cvar_Set("com_target_version", va("%s+%s", TARGET_GAME_VERSION_MOH, PRODUCT_VERSION));
+		Cvar_Set("com_target_shortversion", va("%s+%s", TARGET_GAME_VERSION_MOH, PRODUCT_VERSION));
 		Cvar_Set("com_target_extension", PRODUCT_EXTENSION_MOH);
+        Cvar_Set("com_target_version", va("Medal of Honor %s %s", com_target_extension->string, com_target_shortversion->string));
 		Cvar_Set("com_gamename", TARGET_GAME_NAME_MOH);
 		// "main" is already used as first argument of FS_Startup
 		Cvar_Set("fs_basegame", "");
@@ -3151,8 +3161,9 @@ void Com_InitTargetGameWithType(target_game_e target_game, qboolean bIsDemo)
 		}
 		protocol_version_demo = PROTOCOL_MOHTA_DEMO;
 		protocol_version_full = PROTOCOL_MOHTA;
-		Cvar_Set("com_target_version", va("%s+%s", TARGET_GAME_VERSION_MOHTA, PRODUCT_VERSION));
+		Cvar_Set("com_target_shortversion", va("%s+%s", TARGET_GAME_VERSION_MOHTA, PRODUCT_VERSION));
 		Cvar_Set("com_target_extension", PRODUCT_EXTENSION_MOHTA);
+        Cvar_Set("com_target_version", va("Medal of Honor %s %s", com_target_extension->string, com_target_shortversion->string));
 		Cvar_Set("com_gamename", TARGET_GAME_NAME_MOHTA);
 		if (!bIsDemo) {
 			Cvar_Set("fs_basegame", "mainta");
@@ -3168,17 +3179,18 @@ void Com_InitTargetGameWithType(target_game_e target_game, qboolean bIsDemo)
 			Cvar_Set("com_protocol", va("%i", PROTOCOL_MOHTA));
             Cvar_Set("com_legacyprotocol", va("%i", PROTOCOL_MOHTA));
             Cvar_Set("com_protocol_alt", va("%i", PROTOCOL_MOHTA_DEMO));
-            Cvar_Set("com_target_version", va("%s+%s", TARGET_GAME_VERSION_MOHTT, PRODUCT_VERSION));
+            Cvar_Set("com_target_shortversion", va("%s+%s", TARGET_GAME_VERSION_MOHTT, PRODUCT_VERSION));
 		} else {
 			Cvar_Set("com_protocol", va("%i", PROTOCOL_MOHTA_DEMO));
             Cvar_Set("com_legacyprotocol", va("%i", PROTOCOL_MOHTA_DEMO));
             Cvar_Set("com_protocol_alt", va("%i", PROTOCOL_MOHTA));
-            Cvar_Set("com_target_version", va("%s+%s", TARGET_GAME_VERSION_MOHTT_DEMO, PRODUCT_VERSION));
+            Cvar_Set("com_target_shortversion", va("%s+%s", TARGET_GAME_VERSION_MOHTT_DEMO, PRODUCT_VERSION));
         }
         protocol_version_demo = PROTOCOL_MOHTA_DEMO;
         protocol_version_full = PROTOCOL_MOHTA;
         Cvar_Set("com_protocol_alt", va("%i", PROTOCOL_MOHTA));
 		Cvar_Set("com_target_extension", PRODUCT_EXTENSION_MOHTT);
+        Cvar_Set("com_target_version", va("Medal of Honor: %s %s", com_target_extension->string, com_target_shortversion->string));
 		Cvar_Set("com_gamename", TARGET_GAME_NAME_MOHTT);
 		if (!bIsDemo) {
 			Cvar_Set("fs_basegame", "maintt");

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1057,9 +1057,12 @@ extern	cvar_t* com_legacyprotocol;
 #ifndef DEDICATED
 extern  cvar_t* con_autochat;
 #endif
-extern	cvar_t* com_target_version;
 extern	cvar_t* com_target_game;
+extern	cvar_t* com_target_shortversion;
+extern	cvar_t* com_target_version;
+extern	cvar_t* com_target_extension;
 extern	cvar_t* com_target_demo;
+
 extern	cvar_t* com_updatecheck_enabled;
 extern	cvar_t* com_updatecheck_interval;
 

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -624,9 +624,9 @@ void SVC_Info( netadr_t from ) {
 	}
 
     if (!com_target_demo->integer || com_target_game->integer <= TG_MOH) {
-        Info_SetValueForKey(infostring, "gamever", com_target_version->string);
+        Info_SetValueForKey(infostring, "gamever", com_target_shortversion->string);
 	} else {
-		Info_SetValueForKey(infostring, "gamever", va("d%s", com_target_version->string));
+		Info_SetValueForKey(infostring, "gamever", va("d%s", com_target_shortversion->string));
 	}
 
 	if (com_target_game->integer >= TG_MOHTT) {


### PR DESCRIPTION
- Make the original game version appear first
- Use com_target_shortversion for the short version number
- Use com_target_version for the original game version

Some software such as HLSW as well as some mods check if the beginning of the version string starts with `Medal of Honor ...`.

Fixes #624, #625