### PR TITLE
Add contextual print feature for clients

### DIFF
--- a/code/fgame/g_local.h
+++ b/code/fgame/g_local.h
@@ -422,6 +422,8 @@ void        G_ClientBegin(gentity_t *ent, usercmd_t *cmd);
 void        G_SetClientConfigString(gentity_t *ent);
 void        G_ClientCommand(gentity_t *ent);
 
+void        G_PrintfClient(gentity_t *ent, const char *fmt, ...);
+
 //
 // g_active.c
 //

--- a/code/fgame/g_public.h
+++ b/code/fgame/g_public.h
@@ -487,6 +487,11 @@ typedef struct gameImport_s {
     // Added in OPM
     //
 
+    /**
+     * Print a message related to a client
+     */
+    void (*PrintfClient)(int clientNum, const char *fmt, ...);
+
     int (*pvssoundindex)(const char* name, int streamed);
 
     cvar_t *fsDebug;

--- a/code/fgame/player.cpp
+++ b/code/fgame/player.cpp
@@ -2818,15 +2818,11 @@ void Player::Obituary(Entity *attacker, Entity *inflictor, int meansofdeath, int
         if (bDispLocation && g_obituarylocation->integer) {
             str szConv2 = s2 + " in the " + G_LocationNumToDispString(iLocation);
 
-            if (dedicated->integer) {
-                gi.Printf("%s %s\n", client->pers.netname, gi.LV_ConvertString(szConv2.c_str()));
-            }
+            G_PrintfClient(edict, "%s\n", szConv2.c_str());
 
             G_PrintDeathMessage(s1, szConv2.c_str(), "x", client->pers.netname, this, "s");
         } else {
-            if (dedicated->integer) {
-                gi.Printf("%s %s\n", client->pers.netname, gi.LV_ConvertString(s1.c_str()));
-            }
+            G_PrintfClient(edict, "%s\n", s1.c_str());
 
             G_PrintDeathMessage(s1.c_str(), s2.c_str(), "x", client->pers.netname, this, "s");
         }
@@ -2948,16 +2944,10 @@ void Player::Obituary(Entity *attacker, Entity *inflictor, int meansofdeath, int
 
                 szLoc1 = gi.LV_ConvertString(s1.c_str());
                 if (s2 == 'x') {
-                    gi.Printf("%s %s %s\n", client->pers.netname, szLoc1.c_str(), attacker->client->pers.netname);
+                    G_PrintfClient(edict, "%s %s\n", szLoc1.c_str(), attacker->client->pers.netname);
                 } else {
                     szLoc2 = gi.LV_ConvertString(szConv2.c_str());
-                    gi.Printf(
-                        "%s %s %s%s\n",
-                        client->pers.netname,
-                        szLoc1.c_str(),
-                        attacker->client->pers.netname,
-                        szLoc2.c_str()
-                    );
+                    G_PrintfClient(edict, "%s %s%s\n", szLoc1.c_str(), attacker->client->pers.netname, szLoc2.c_str());
                 }
             }
         } else {
@@ -2970,16 +2960,10 @@ void Player::Obituary(Entity *attacker, Entity *inflictor, int meansofdeath, int
 
                 szLoc1 = gi.LV_ConvertString(s1.c_str());
                 if (s2 == 'x') {
-                    gi.Printf("%s %s %s\n", client->pers.netname, szLoc1.c_str(), attacker->client->pers.netname);
+                    G_PrintfClient(edict, "%s %s\n", szLoc1.c_str(), attacker->client->pers.netname);
                 } else {
                     szLoc2 = gi.LV_ConvertString(s2.c_str());
-                    gi.Printf(
-                        "%s %s %s%s\n",
-                        client->pers.netname,
-                        szLoc1.c_str(),
-                        attacker->client->pers.netname,
-                        szLoc2.c_str()
-                    );
+                    G_PrintfClient(edict, "%s %s%s\n", szLoc1.c_str(), attacker->client->pers.netname, szLoc2.c_str());
                 }
             }
         }
@@ -3027,17 +3011,11 @@ void Player::Obituary(Entity *attacker, Entity *inflictor, int meansofdeath, int
             str szConv2 = s2 + " in the " + G_LocationNumToDispString(iLocation);
 
             G_PrintDeathMessage(s1.c_str(), szConv2.c_str(), "x", client->pers.netname, this, "w");
-
-            if (dedicated->integer) {
-                gi.Printf("%s %s\n", client->pers.netname, gi.LV_ConvertString(s1.c_str()));
-            }
         } else {
             G_PrintDeathMessage(s1.c_str(), s2.c_str(), "x", client->pers.netname, this, "w");
-
-            if (dedicated->integer) {
-                gi.Printf("%s %s\n", client->pers.netname, gi.LV_ConvertString(s1.c_str()));
-            }
         }
+
+        G_PrintfClient(edict, "%s\n", gi.LV_ConvertString(s1.c_str()));
     }
 }
 
@@ -9543,14 +9521,16 @@ void Player::Join_DM_Team(Event *ev)
         // a player joined a team
         //
         if (GetTeam() == TEAM_ALLIES) {
-            join_message = "has joined the Allies";
+            join_message = gi.LV_ConvertString("has joined the Allies");
         } else if (GetTeam() == TEAM_AXIS) {
-            join_message = "has joined the Axis";
+            join_message = gi.LV_ConvertString("has joined the Axis");
         } else {
             return;
         }
 
-        G_PrintToAllClients(va("%s %s\n", client->pers.netname, gi.LV_ConvertString(join_message)), 2);
+        G_PrintfClient(edict, "%s\n", join_message);
+
+        G_PrintToAllClients(va("%s %s\n", client->pers.netname, join_message), 2);
     }
 }
 
@@ -9999,6 +9979,7 @@ void Player::CallVote(Event *ev)
         }
     }
 
+    G_PrintfClient(edict, "called a vote (%s %s)\n", arg1.c_str(), arg2.c_str());
     G_PrintToAllClients(va("%s %s.\n", client->pers.netname, gi.LV_ConvertString("called a vote")));
 
     level.m_voteTime = (level.svsFloatTime - level.svsStartFloatTime) * 1000;
@@ -10882,13 +10863,9 @@ void Player::EventDMMessage(Event *ev)
 
         // Added in OPM
         if (bInstaMessage) {
-            gi.Printf(
-                "%s (%zu) says (voice) to everyone: %s\n", client->pers.netname, edict - g_entities, pStartMessage
-            );
+            G_PrintfClient(edict, "shouts @all: %s\n", pStartMessage);
         } else {
-            gi.Printf(
-                "%s (%zu) says (text) to everyone: %s\n", client->pers.netname, edict - g_entities, pStartMessage
-            );
+            G_PrintfClient(edict, "says @all: %s\n", pStartMessage);
         }
 
         if (!IsSpectator() || g_spectate_allow_full_chat->integer) {
@@ -10947,9 +10924,9 @@ void Player::EventDMMessage(Event *ev)
 
         // Added in OPM
         if (bInstaMessage) {
-            gi.Printf("%s (%zu) says (voice) to team: %s\n", client->pers.netname, edict - g_entities, pStartMessage);
+            G_PrintfClient(edict, "shouts @team: %s\n", pStartMessage);
         } else {
-            gi.Printf("%s (%zu) says (text) to team: %s\n", client->pers.netname, edict - g_entities, pStartMessage);
+            G_PrintfClient(edict, "says @team: %s\n", pStartMessage);
         }
 
         if (IsSpectator()) {
@@ -11022,21 +10999,9 @@ void Player::EventDMMessage(Event *ev)
 
         // Added in OPM
         if (bInstaMessage) {
-            gi.Printf(
-                "%s (%zu) says (voice) to client #%d: %s\n",
-                client->pers.netname,
-                edict - g_entities,
-                iMode - 1,
-                pStartMessage
-            );
+            G_PrintfClient(edict, "shouts @#%d: %s\n", iMode - 1, pStartMessage);
         } else {
-            gi.Printf(
-                "%s (%zu) says (text) to client #%d: %s\n",
-                client->pers.netname,
-                edict - g_entities,
-                iMode - 1,
-                pStartMessage
-            );
+            G_PrintfClient(edict, "says @#%d: %s\n", iMode - 1, pStartMessage);
         }
 
         gi.SendServerCommand(iMode - 1, "%s\n", szPrintString);

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -389,6 +389,8 @@ extern	cvar_t	*sv_strictAuth;
 #endif
 extern	cvar_t	*sv_banFile;
 
+extern  cvar_t  *sv_logContext;
+
 extern	serverBan_t serverBans[SERVER_MAXBANS];
 extern	int serverBansCount;
 
@@ -436,6 +438,8 @@ void SV_RemoveOperatorCommands (void);
 void SV_MasterHeartbeat (void);
 void SV_MasterShutdown (void);
 int SV_RateMsec(client_t *client);
+
+void SV_PrintfClient(int clientNum, const char *fmt, ...);
 
 void SV_ArchiveHudDrawElements( qboolean loading );
 void SV_HudDrawShader( int iInfo, const char *name );

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -622,7 +622,7 @@ gotnewcl:
 
     // Added in OPM
     //  Show the IP address of the client that is connecting
-    Com_Printf("Client %i (address %s) is connecting\n", i, ip);
+    Com_Printf("Client %i (IP: %s) is connecting\n", clientNum, ip);
 
 	ch = FindChallenge(from, qfalse);
 	if (ch) {
@@ -1511,10 +1511,12 @@ void SV_UserinfoChanged( client_t *cl ) {
     // Added in OPM
     //  Print name changes
     //
-    if (!oldname[0]) {
-        Com_Printf("Client %i name set to '%s'\n", cl - svs.clients, cl->name);
-    } else if (strcmp(oldname, cl->name)) {
-        Com_Printf("Client %i changed name from '%s' to '%s'\n", cl - svs.clients, oldname, cl->name);
+    if (cl->state != CS_FREE) {
+        if (!oldname[0]) {
+            SV_PrintfClient(cl - svs.clients, "is using this name\n");
+        } else if (strcmp(oldname, cl->name)) {
+            SV_PrintfClient(cl - svs.clients, "has changed name (old name was '%s')\n", oldname);
+        }
     }
 
 	// rate command

--- a/code/server/sv_game.c
+++ b/code/server/sv_game.c
@@ -1910,6 +1910,7 @@ void SV_InitGameProgs( void ) {
 	import.fsDebug						= fs_debug;
 
 	// Added in OPM
+    import.PrintfClient                 = SV_PrintfClient;
 	import.pvssoundindex				= SV_PVSSoundIndex;
 
 	ge = Sys_GetGameAPI( &import );

--- a/code/server/sv_init.c
+++ b/code/server/sv_init.c
@@ -1101,6 +1101,9 @@ void SV_Init (void)
 #endif
 	sv_banFile = Cvar_Get("sv_banFile", "serverbans.dat", CVAR_ARCHIVE);
 
+    // Added in OPM
+    sv_logContext = Cvar_Get("sv_logContext", "1", 0);
+
 	Q_strncpyz( svs.gameName, "current", sizeof(svs.gameName) );
 
 	// dday vars


### PR DESCRIPTION
This logs client messages like this:

```
{#0 | 10.2.3.4:12203} *** Blank Name *** took himself out of commision
{#0 | 10.2.3.4:12203} *** Blank Name *** played catch with himself
{#0 | 10.2.3.4:12203} *** Blank Name *** says @all: test
{#0 | 10.2.3.4:12203} *** Blank Name *** tripped on his own grenade
```

Can be disabled with `sv_logContext 0`