### PR TITLE
Improve stufftext filtering

### DIFF
--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -374,7 +374,7 @@ static void CG_ServerCommand(qboolean modelOnly)
 
     if (!strcmp(cmd, "stufftext")) {
         char *cmd = cgi.Argv(1);
-        if (CG_IsStatementFiltered(cmd)) {
+        if (!CG_IsStatementAllowed(cmd)) {
             // Added in OPM
             //  Don't execute filtered commands
             return;

--- a/code/cgame/cg_servercmds_filter.h
+++ b/code/cgame/cg_servercmds_filter.h
@@ -27,4 +27,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
-qboolean CG_IsStatementFiltered(char *cmd);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Determines whether or not the full statement is allowed.
+ * The statement will be allowed if conditions are met:
+ *  - Contains a whitelisted command
+ *  - Trying to set a whitelisted variable
+ *  - Trying to set variable that doesn't exist (user created variables)
+ */
+qboolean CG_IsStatementAllowed(char *cmd);
+
+#ifdef __cplusplus
+}
+#endif

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -885,6 +885,25 @@ void CL_MapLoading( qboolean flush, const char *pszMapName ) {
 
 /*
 =====================
+CL_CleanupUserInfo
+
+Remove user-created userinfo variables
+=====================
+*/
+void CL_CleanupUserInfo()
+{
+    cvar_t *cv;
+    cvar_t *next;
+
+    for(cv = Cvar_Next(NULL), next = cv->next; cv; cv = next, next = Cvar_Next(cv)) {
+        if ((cv->flags & CVAR_USER_CREATED) && (cv->flags & CVAR_USERINFO)) {
+            Cvar_Unset(cv);
+        }
+    }
+}
+
+/*
+=====================
 CL_ClearState
 
 Called before parsing a gamestate
@@ -901,6 +920,9 @@ void CL_ClearState( void )
 	UI_ClearState();
 
 	Com_Memset( &cl, 0, sizeof( clientActive_t ) );
+
+    // Added in OPM
+    CL_CleanupUserInfo();
 }
 
 /*

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -702,6 +702,8 @@ void	Cvar_SaveGameRestart_f( void );
 
 void	Cvar_CompleteCvarName(const char* args, int argNum);
 
+cvar_t  *Cvar_Unset(cvar_t *cv);
+
 extern	int			cvar_modifiedFlags;
 extern	qboolean	cvar_global_force;
 // whenever a cvar is modifed, its flags will be OR'd into this, so


### PR DESCRIPTION
- Use `allow` rather than `filter`, as it checks for allowed commands rather than prohibited commands
- Allow userinfo variables to be created by the server

Userinfo variables are now removed when disconnecting, some servers use userinfo variables for custom settings or to store temporary information, which makes them irrelevant on other servers and use space.
