### PR TITLE
Add unit test support

### DIFF
--- a/.github/workflows/shared-build-linux.yml
+++ b/.github/workflows/shared-build-linux.yml
@@ -213,14 +213,6 @@ jobs:
       run: |
         cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
-    - name: Test
-      working-directory: ${{github.workspace}}
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: |
-        cd "${{github.workspace}}/build"
-        ctest -C ${{env.BUILD_TYPE}}
-
     - name: Install
       working-directory: ${{github.workspace}}
       # Install to the directory defined in CMAKE_INSTALL_PREFIX

--- a/.github/workflows/shared-build-macos.yml
+++ b/.github/workflows/shared-build-macos.yml
@@ -206,14 +206,6 @@ jobs:
       run: |
         cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
-    - name: Test
-      working-directory: ${{github.workspace}}
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: |
-        cd "${{github.workspace}}/build"
-        ctest -C ${{env.BUILD_TYPE}}
-
     - name: Install
       working-directory: ${{github.workspace}}
       # Install to the directory defined in CMAKE_INSTALL_PREFIX

--- a/.github/workflows/shared-build-windows.yml
+++ b/.github/workflows/shared-build-windows.yml
@@ -219,14 +219,6 @@ jobs:
       run: |
         cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
-    - name: Test
-      working-directory: ${{github.workspace}}
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: |
-        cd "${{github.workspace}}/build"
-        ctest -C ${{env.BUILD_TYPE}}
-
     - name: Install
       working-directory: ${{github.workspace}}
       # Install to the directory defined in CMAKE_INSTALL_PREFIX

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,0 +1,53 @@
+name: "Unit testing"
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Running unit tests"
+    runs-on: ubuntu-latest
+    environment: "testing"
+
+    steps:
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      name: Install required packages
+      with:
+        packages: flex bison ninja-build cmake clang libsdl2-dev libopenal-dev
+        version: "${{ runner.os }}-${{ runner.arch }}-unittest-v1"
+
+    - uses: actions/checkout@v4
+      with:
+        path: 'source'
+
+    - name: Settings
+      working-directory: ${{github.workspace}}
+      run: |
+        echo "CMAKE_GENERATOR=Ninja Multi-Config" >> $GITHUB_ENV
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
+        echo "CMAKE_PARAM=--log-level=VERBOSE \
+        -DCMAKE_INSTALL_PREFIX='${{github.workspace}}/install'" >> $GITHUB_ENV
+
+    - name: Configure CMake
+      working-directory: ${{github.workspace}}
+      run: |
+        cmake -B ./build ${{ env.CMAKE_PARAM }} ./source
+
+    - name: Build
+      working-directory: ${{github.workspace}}
+      run: |
+        cmake --build ${{github.workspace}}/build --config Debug --parallel
+
+    - name: Test
+      working-directory: ${{github.workspace}}
+      run: |
+        cd "${{github.workspace}}/build"
+        ctest -C Debug --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ endif()
 set(CMAKE_INSTALL_BINDIR ${CMAKE_DEFAULT_INSTALL_RUNTIME_DIR} CACHE PATH "Binary dir")
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_BINDIR} CACHE PATH "Library dir")
 include(GNUInstallDirs)
+# Enable unit testing
+include(CTest)
 
 #
 # Common stuff

--- a/code/qcommon/CMakeLists.txt
+++ b/code/qcommon/CMakeLists.txt
@@ -118,3 +118,17 @@ else()
 	target_include_directories(qcommon INTERFACE ${ZLIB_INCLUDE_DIRS})
 	target_link_libraries(qcommon_standalone INTERFACE ${ZLIB_LIBRARIES})
 endif()
+
+#
+# Unit tests
+#
+
+enable_testing()
+
+add_library(testing INTERFACE)
+target_sources(testing INTERFACE q_shared.c common_light.c)
+
+add_executable(test_lz77 tests/test_lz77.cpp lz77.cpp)
+target_link_libraries(test_lz77 INTERFACE testing)
+add_test(NAME test_lz77 COMMAND test_lz77)
+set_tests_properties(test_lz77 PROPERTIES TIMEOUT 15)

--- a/code/qcommon/common_light.c
+++ b/code/qcommon/common_light.c
@@ -1,0 +1,52 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+#include "q_shared.h"
+#include <stdarg.h>
+
+void QDECL Com_Printf( const char *fmt, ... ) {
+    va_list argptr;
+    char    text[1024];
+
+    va_start(argptr, msg);
+    Q_vsnprintf(text, sizeof(text), msg, argptr);
+    va_end(argptr);
+
+    printf("%s", text);
+}
+
+void QDECL Com_DPrintf( const char *fmt, ...) {
+    va_list argptr;
+    char    text[1024];
+
+    va_start(argptr, msg);
+    Q_vsnprintf(text, sizeof(text), msg, argptr);
+    va_end(argptr);
+
+    printf("%s", text);
+}
+
+void QDECL Com_DPrintf2( const char *fmt, ...) {
+}
+
+void QDECL Com_Error( int code, const char *fmt, ... ) {
+}

--- a/code/qcommon/lz77.cpp
+++ b/code/qcommon/lz77.cpp
@@ -407,7 +407,7 @@ int cLZ77::Decompress(unsigned char *in, size_t in_len, unsigned char *out, size
 static unsigned char in[0x40000];
 static unsigned char out[0x41013];
 
-void test_compression()
+static void test_compression()
 {
     size_t in_len;
     size_t out_len;

--- a/code/qcommon/tests/test_lz77.cpp
+++ b/code/qcommon/tests/test_lz77.cpp
@@ -1,0 +1,80 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+#include "../lz77.h"
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+
+static unsigned char in[0x40000];
+static unsigned char out[0x41013];
+static size_t        out_len;
+
+bool test_compression()
+{
+    cLZ77 lz77;
+
+    memset(&in, 0, 0x40000);
+
+    if (lz77.Compress(in, sizeof(in), out, &out_len)) {
+        return false;
+    }
+
+    std::cout << "Compressed " << sizeof(in) << " bytes into " << out_len << " bytes" << std::endl;
+    return true;
+}
+
+bool test_decompression()
+{
+    size_t in_len;
+    size_t new_len;
+    cLZ77  lz77;
+
+    in_len = 0;
+    lz77.Decompress(out, out_len, in, &in_len);
+    new_len = in_len;
+
+    if (in_len != 0x40000) {
+        std::cerr << "Decompression got FuBar'd... " << sizeof(in) << " != " << new_len << std::endl;
+        return false;
+    }
+
+    std::cout << "Decompressed " << out_len << " bytes into " << sizeof(in) << " bytes" << std::endl;
+
+    return true;
+}
+
+int main(int argc, char *argv[])
+{
+    if (!test_compression()) {
+        std::cerr << "Compression Failed!" << std::endl;
+        return 1;
+    }
+
+    if (!test_decompression()) {
+        std::cerr << "Decompression Failed!" << std::endl;
+        return 2;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This adds simple support for unit testing, starting with the LZ77 compressor.
- Unit tests run on a separate GitHub Actions workflow
- Remove CTest commands from shared build workflow
