### PR TITLE
Use v2.2.2 of action-gh-release

### DIFF
--- a/.github/workflows/tags-publish-release.yml
+++ b/.github/workflows/tags-publish-release.yml
@@ -61,7 +61,7 @@ jobs:
       run: zip -r "../${{ env.RELEASE_NAME }}.zip" ./
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v2.2.2
       with:
         name: '${{github.ref_name}}-${{env.RELEASE_STAGE}}'
         prerelease: ${{env.RELEASE_IS_PRERELEASE}}
@@ -96,7 +96,7 @@ jobs:
         cp Setup.msi ../${{ env.RELEASE_NAME }}.msi
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v2.2.2
       with:
         name: '${{github.ref_name}}-${{env.RELEASE_STAGE}}'
         prerelease: ${{env.RELEASE_IS_PRERELEASE}}


### PR DESCRIPTION
This is due to this bug: https://github.com/softprops/action-gh-release/issues/628