### PR TITLE
Use a debug print rather than an error drop when the reference count for an area is negative

### DIFF
--- a/code/qcommon/cm_test.c
+++ b/code/qcommon/cm_test.c
@@ -453,7 +453,7 @@ void	CM_AdjustAreaPortalState( int area1, int area2, qboolean open ) {
 		cm.areaPortals[ area1 * cm.numAreas + area2 ]--;
 		cm.areaPortals[ area2 * cm.numAreas + area1 ]--;
 		if ( cm.areaPortals[ area2 * cm.numAreas + area1 ] < 0 ) {
-			Com_Error (ERR_DROP, "CM_AdjustAreaPortalState: negative reference count");
+			Com_DPrintf("CM_AdjustAreaPortalState: negative reference count\n");
 		}
 	}
 


### PR DESCRIPTION
Fixes #732, fixes #595

Original Quake III implementation will drop an error if there is a negative reference count, they changed that in MOHAA.