### PR TITLE
Capitalize the first letter of ammo type

### DIFF
--- a/code/fgame/ammo.cpp
+++ b/code/fgame/ammo.cpp
@@ -100,7 +100,7 @@ Item *AmmoEntity::ItemPickup(Entity *other, qboolean add_to_inventory)
     gi.SendServerCommand(
         other->edict - g_entities,
         "print \"" HUD_MESSAGE_YELLOW "%s\"",
-        gi.LV_ConvertString(va("Got %d %s Rounds", amount, item_name.c_str()))
+        gi.LV_ConvertString(va("Got %d %s Rounds", amount, GetCapitalized(item_name).c_str()))
     );
 
     // Give the ammo to the player

--- a/code/fgame/weapon.cpp
+++ b/code/fgame/weapon.cpp
@@ -3036,7 +3036,7 @@ void Weapon::PickupWeapon(Event *ev)
         const str& sAmmoType = ammo_type[FIRE_PRIMARY];
 
         sen->GiveAmmo(sAmmoType, iGiveAmmo);
-
+        
         if (!sAmmoType.icmp("grenade") || !sAmmoType.icmp("agrenade")) {
             if (iGiveAmmo == 1) {
                 sMessage = gi.LV_ConvertString("Got 1 Grenade");
@@ -3044,7 +3044,7 @@ void Weapon::PickupWeapon(Event *ev)
                 sMessage = gi.LV_ConvertString(va("Got %i Grenades", iGiveAmmo));
             }
         } else {
-            sMessage = gi.LV_ConvertString(va("Got %i %s Rounds", iGiveAmmo, sAmmoType.c_str()));
+            sMessage = gi.LV_ConvertString(va("Got %i %s Rounds", iGiveAmmo, GetCapitalized(sAmmoType).c_str()));
         }
 
         gi.SendServerCommand(other->edict - g_entities, "print \"" HUD_MESSAGE_YELLOW "%s\n\"", sMessage.c_str());
@@ -3072,7 +3072,7 @@ void Weapon::PickupWeapon(Event *ev)
                     sMessage = gi.LV_ConvertString(va("Got %i Rifle Grenades", iGiveAmmo));
                 }
             } else {
-                sMessage = gi.LV_ConvertString(va("Got %i %s Rounds", startammo[FIRE_PRIMARY], sAmmoType.c_str()));
+                sMessage = gi.LV_ConvertString(va("Got %i %s Rounds", startammo[FIRE_PRIMARY], GetCapitalized(sAmmoType).c_str()));
             }
 
             gi.SendServerCommand(other->edict - g_entities, "print \"" HUD_MESSAGE_YELLOW "%s\n\"", sMessage.c_str());

--- a/code/qcommon/str.cpp
+++ b/code/qcommon/str.cpp
@@ -731,6 +731,20 @@ void TestStringClass(void)
     a[1] = '1'; // a.data = "t1st", b.data = "test"
 }
 
+str GetCapitalized(const str& value)
+{
+    str newValue;
+    size_t i;
+
+    if (!value.length()) {
+        return "";
+    }
+
+    newValue += (char)toupper(value[0]);
+    newValue += value.c_str() + 1;
+    return newValue;
+}
+
 #ifdef _WIN32
 #    pragma warning(default : 4189) // local variable is initialized but not referenced
 #    pragma warning(disable : 4514) // unreferenced inline function has been removed

--- a/code/qcommon/str.h
+++ b/code/qcommon/str.h
@@ -673,3 +673,5 @@ inline str::operator const char *(void) const
 {
     return c_str();
 }
+
+str GetCapitalized(const str& value);


### PR DESCRIPTION
Fixes #760.

This fixes an issue where the ammo pickup message would not get localized.