### PR TITLE
Fix ephemeral event being passed multiple times after being freed with multiple widgets of the same name

### DIFF
--- a/code/uilib/uimenu.cpp
+++ b/code/uilib/uimenu.cpp
@@ -499,6 +499,7 @@ void Menu::PassEventToWidget
 		if( wid->getName() == name && wid->ValidEvent( ev->getName() ) )
 		{
 			wid->ProcessEvent( ev );
+            return;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #764