### PR TITLE
Fix(build): Use false instead of NULL for boolean in initializer

### DIFF
--- a/code/client/snd_openal_new.cpp
+++ b/code/client/snd_openal_new.cpp
@@ -487,7 +487,7 @@ static bool S_OPENAL_InitExtensions()
                             "alGetStringiSOFT", (void **)&qalGetStringiSOFT,
                             false, },
 #endif
-        extensions_table_t {NULL, NULL, NULL}
+        extensions_table_t {NULL, NULL, false}
     };
 
     extensions_table_t *i;


### PR DESCRIPTION
This PR replaces `NULL` with `false` for a boolean member in an `extensions_table_t` initializer to fix C++ type-mismatch build error on modern C++ compilers.