### PR TITLE
fix(renderering): add an option for culling farplane only when rendering a portal sky

### DIFF
--- a/code/fgame/worldspawn.cpp
+++ b/code/fgame/worldspawn.cpp
@@ -766,7 +766,11 @@ void World::SetFarPlane_Color(Event *ev)
 
 void World::SetFarPlane_Cull(Event *ev)
 {
-    farplane_cull = ev->GetBoolean(1);
+    //farplane_cull = ev->GetBoolean(1);
+    // Changed in 2.0
+    //  Allow farplane_cull to cull if the sky is not a portal sky.
+    //  See FARPLANE_CULL_ in rendererglx/tr_local.h for values.
+    farplane_cull = ev->GetInteger(1);
     UpdateFog();
 }
 

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -724,6 +724,13 @@ typedef struct depthfog_s {
 	int extrafrustums;
 } depthfog_t;
 
+// Doesn't cull anything
+#define FARPLANE_CULL_NONE			0
+// Cull outside the maximum distance
+#define FARPLANE_CULL_STANDARD		1
+// Cull outside the maximum distance ONLY if the view is a portal sky
+#define FARPLANE_CULL_PORTALSKY		2
+
 typedef struct {
 	orientationr_t	ori;
 	orientationr_t	world;
@@ -744,7 +751,7 @@ typedef struct {
     float		farplane_distance;
     float		farplane_bias; // added in 2.0
 	float		farplane_color[3];
-    qboolean	farplane_cull;
+    int			farplane_cull;
     qboolean	renderTerrain; // added in 2.0
 } viewParms_t;
 

--- a/code/renderergl1/tr_main.c
+++ b/code/renderergl1/tr_main.c
@@ -652,11 +652,11 @@ void R_SetupFrustum (void) {
 			);
 
 			if (r_farplane_nocull->integer > 0) {
-				tr.viewParms.farplane_cull = 0;
+				tr.viewParms.farplane_cull = FARPLANE_CULL_NONE;
 			} else if (r_farplane_nocull->integer == 0) {
-				tr.viewParms.farplane_cull = 1;
+				tr.viewParms.farplane_cull = FARPLANE_CULL_STANDARD;
             } else {
-                tr.viewParms.farplane_cull = 2;
+                tr.viewParms.farplane_cull = FARPLANE_CULL_PORTALSKY;
             }
 		}
 	}
@@ -673,11 +673,11 @@ void R_SetupFrustum (void) {
 			&tr.viewParms.farplane_color[2]);
 
 			if (r_farplane_nocull->integer > 0) {
-				tr.viewParms.farplane_cull = 0;
+				tr.viewParms.farplane_cull = FARPLANE_CULL_NONE;
 			} else if (r_farplane_nocull->integer == 0) {
-				tr.viewParms.farplane_cull = 1;
+				tr.viewParms.farplane_cull = FARPLANE_CULL_STANDARD;
             } else {
-                tr.viewParms.farplane_cull = 2;
+                tr.viewParms.farplane_cull = FARPLANE_CULL_PORTALSKY;
             }
 	}
 
@@ -698,7 +698,7 @@ void R_SetupFrustum (void) {
 		SetPlaneSignbits(&tr.viewParms.frustum[4]);
 
 		tr.viewParms.fog.enabled = r_farplane_nofog->integer == 0;
-		if (tr.viewParms.farplane_cull) {
+		if (tr.viewParms.farplane_cull != FARPLANE_CULL_NONE) {
 			// extra fustum for culling
 			tr.viewParms.fog.extrafrustums = 1;
 		} else {

--- a/code/renderergl1/tr_world.c
+++ b/code/renderergl1/tr_world.c
@@ -581,7 +581,9 @@ static void R_RecursiveWorldNode( mnode_t *node, int planeBits, int dlightBits )
 				}
 			}
 
-			if (planeBits & 16) {
+			// Changed in 2.0
+			//  Allow culling only if the view is a portal sky
+			if ((planeBits & 16) && (tr.viewParms.farplane_cull < FARPLANE_CULL_PORTALSKY || tr.viewParms.isPortalSky)) {
 				r = BoxOnPlaneSide(node->mins, node->maxs, &tr.viewParms.frustum[4]);
 				if (r == 2) {
 					return;						// culled

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -982,6 +982,13 @@ typedef struct depthfog_s {
 	int extrafrustums;
 } depthfog_t;
 
+// Doesn't cull anything
+#define FARPLANE_CULL_NONE			0
+// Cull outside the maximum distance
+#define FARPLANE_CULL_STANDARD		1
+// Cull outside the maximum distance ONLY if the view is a portal sky
+#define FARPLANE_CULL_PORTALSKY		2
+
 //=========================
 
 typedef enum {
@@ -1027,7 +1034,7 @@ typedef struct {
     float		farplane_distance;
     float		farplane_bias; // added in 2.0
     float		farplane_color[3];
-    qboolean	farplane_cull;
+    int			farplane_cull;
     qboolean	renderTerrain; // added in 2.0
 } viewParms_t;
 

--- a/code/renderergl2/tr_main.c
+++ b/code/renderergl2/tr_main.c
@@ -762,11 +762,11 @@ void R_SetupFrustum (viewParms_t *dest, float xmin, float xmax, float ymax, floa
 			);
 
 			if (r_farplane_nocull->integer > 0) {
-				dest->farplane_cull = 0;
+				dest->farplane_cull = FARPLANE_CULL_NONE;
 			} else if (r_farplane_nocull->integer == 0) {
-				dest->farplane_cull = 1;
+				dest->farplane_cull = FARPLANE_CULL_STANDARD;
             } else {
-                dest->farplane_cull = 2;
+                dest->farplane_cull = FARPLANE_CULL_PORTALSKY;
             }
 		}
 	}
@@ -783,11 +783,11 @@ void R_SetupFrustum (viewParms_t *dest, float xmin, float xmax, float ymax, floa
 			&dest->farplane_color[2]);
 
 			if (r_farplane_nocull->integer > 0) {
-				dest->farplane_cull = 0;
+				dest->farplane_cull = FARPLANE_CULL_NONE;
 			} else if (r_farplane_nocull->integer == 0) {
-				dest->farplane_cull = 1;
+				dest->farplane_cull = FARPLANE_CULL_STANDARD;
             } else {
-                dest->farplane_cull = 2;
+                dest->farplane_cull = FARPLANE_CULL_PORTALSKY;
             }
 	}
 
@@ -808,7 +808,7 @@ void R_SetupFrustum (viewParms_t *dest, float xmin, float xmax, float ymax, floa
 		SetPlaneSignbits(&dest->frustum[4]);
 
 		dest->fog.enabled = r_farplane_nofog->integer == 0;
-		if (dest->farplane_cull) {
+		if (dest->farplane_cull != FARPLANE_CULL_NONE) {
             // extra fustum for culling
             dest->flags |= VPF_FARPLANEFRUSTUM;
 			dest->fog.extrafrustums = 1;

--- a/code/renderergl2/tr_world.c
+++ b/code/renderergl2/tr_world.c
@@ -457,7 +457,9 @@ static void R_RecursiveWorldNode( mnode_t *node, uint32_t planeBits, uint32_t dl
 				}
 			}
 
-			if ( planeBits & 16 ) {
+			// Changed in 2.0
+			//  Allow culling only if the view is a portal sky
+			if ( ( planeBits & 16 ) && ( tr.viewParms.farplane_cull < FARPLANE_CULL_PORTALSKY || tr.viewParms.isPortalSky ) ) {
 				r = BoxOnPlaneSide(node->mins, node->maxs, &tr.viewParms.frustum[4]);
 				if (r == 2) {
 					return;						// culled


### PR DESCRIPTION
Fixes #817.