### PR TITLE
fix(fgame): remove viewmodel states and only cache players world model

### DIFF
--- a/code/fgame/level.cpp
+++ b/code/fgame/level.cpp
@@ -1633,6 +1633,12 @@ void Level::Precache(void)
             if (!Q_stricmpn(filename, "allied_", 7) || !Q_stricmpn(filename, "american_", 9)
                 || !Q_stricmpn(filename, "german_", 7) || !Q_stricmpn(filename, "IT_", 3)
                 || !Q_stricmpn(filename, "SC_", 3)) {
+                
+                if (filelen >= 8 && !Q_stricmp(filename + filelen - 8, "_fps.tik")) {
+                    // Ignore FPS models
+                    continue;
+                }
+
                 CacheResource(va("models/player/%s", filename));
             }
         }

--- a/code/fgame/player.cpp
+++ b/code/fgame/player.cpp
@@ -1654,6 +1654,7 @@ Event EV_Player_Userinfo
     EV_GETTER
 );
 
+#ifdef OPM_FEATURES
 Event EV_Player_ViewModelGetAnim
 (
     "viewmodelgetanim",
@@ -1682,7 +1683,6 @@ Event EV_Player_ViewModelAnimValid
     EV_RETURN
 );
 
-#ifdef OPM_FEATURES
 Event EV_Player_Earthquake
 (
     "earthquake2",
@@ -1951,10 +1951,10 @@ CLASS_DECLARATION(Sentient, Player, "player") {
     {&EV_Player_Spectator,                &Player::Spectator                    },
     {&EV_Player_StopLocalSound,           &Player::StopLocalSound               },
     {&EV_Player_Userinfo,                 &Player::Userinfo                     },
+#ifdef OPM_FEATURES
     {&EV_Player_ViewModelAnimFinished,    &Player::EventGetViewModelAnimFinished},
     {&EV_Player_ViewModelGetAnim,         &Player::EventGetViewModelAnim        },
     {&EV_Player_ViewModelAnimValid,       &Player::EventGetViewModelAnimValid   },
-#ifdef OPM_FEATURES
     {&EV_Player_Earthquake,               &Player::EventEarthquake              },
     {&EV_Player_SetClientFlag,            &Player::SetClientFlag                },
     {&EV_Player_SetEntityShader,          &Player::SetEntityShader              },
@@ -2193,11 +2193,11 @@ Player::Player()
         speed_multiplier[i] = 1.0f;
     }
 
+#ifdef OPM_FEATURES
     m_fpsTiki  = NULL;
     animDoneVM = true;
     m_fVMAtime = 0;
 
-#ifdef OPM_FEATURES
     m_bShowingHint = false;
 #endif
 }
@@ -2559,7 +2559,9 @@ void Player::InitModel(void)
         }
     }
 
+#ifdef OPM_FEATURES
     InitModelFps();
+#endif
 }
 
 void Player::InitPhysics(void)
@@ -4960,10 +4962,12 @@ void Player::Think(void)
         edict->s.eFlags &= ~EF_PLAYER_TALKING;
     }
 
+#ifdef OPM_FEATURES
     //
     // Added in OPM
     //
     ThinkFPS();
+#endif
 
     server_new_buttons = 0;
 
@@ -11803,6 +11807,7 @@ qboolean Player::ViewModelAnim(str anim, qboolean force_restart, qboolean bFullA
         weapon = newActiveWeapon.weapon;
     }
 
+#ifdef OPM_FEATURES
     if (weapon) {
         m_sVMAcurrent = GetItemPrefix(weapon->getName()) + str("_") + anim;
     } else {
@@ -11818,6 +11823,7 @@ qboolean Player::ViewModelAnim(str anim, qboolean force_restart, qboolean bFullA
     animDoneVM = false;
 
     m_fVMAtime = 0;
+#endif
 
     return true;
 }
@@ -12837,6 +12843,8 @@ int Player::GetNumDeaths(void) const
     return num_deaths;
 }
 
+#ifdef OPM_FEATURES
+
 void Player::InitModelFps(void)
 {
     char  model_name[MAX_STRING_TOKENS];
@@ -12928,8 +12936,6 @@ void Player::EventGetViewModelAnimValid(Event *ev)
         ev->AddInteger(1);
     }
 }
-
-#ifdef OPM_FEATURES
 
 void Player::EventEarthquake(Event *ev)
 {

--- a/code/fgame/player.h
+++ b/code/fgame/player.h
@@ -368,6 +368,7 @@ public:
     bool              m_bConnected;
     str               m_lastcommand;
 
+#ifdef OPM_FEATURES
     //
     // View model animation
     //
@@ -377,6 +378,7 @@ public:
     str                 m_sVMcurrent;
     float               m_fVMAtime;
     dtiki_t            *m_fpsTiki;
+#endif
 
 private:
     int m_iInstantMessageTime;
@@ -504,8 +506,10 @@ public:
     //====
     qboolean CondClientCommand(Conditional& condition);
     qboolean CondVariable(Conditional& condition);
+#ifdef OPM_FEATURES
     qboolean CondAnimDoneVM(Conditional& condition);
     qboolean CondVMAnim(Conditional& condition);
+#endif
     //====
 
     // movecontrol functions
@@ -973,13 +977,13 @@ public:
     void StopLocalSound(Event *ev);
     void Userinfo(Event *ev);
 
+#ifdef OPM_FEATURES
     void InitModelFps();
     void ThinkFPS();
     void EventGetViewModelAnim(Event *ev);
     void EventGetViewModelAnimFinished(Event *ev);
     void EventGetViewModelAnimValid(Event *ev);
 
-#ifdef OPM_FEATURES
     void EventEarthquake(Event *ev);
     void SetClientFlag(Event *ev);
     void SetEntityShader(Event *ev);
@@ -1240,12 +1244,14 @@ inline void Player::Archive(Archiver& arc)
         arc.ArchiveFloat(&speed_multiplier[i]);
     }
 
+#ifdef OPM_FEATURES
     if (arc.Loading()) {
         InitModelFps();
     }
 
     arc.ArchiveBool(&animDoneVM);
     arc.ArchiveFloat(&m_fVMAtime);
+#endif
 }
 
 inline Camera *Player::CurrentCamera(void)

--- a/code/fgame/player_conditionals.cpp
+++ b/code/fgame/player_conditionals.cpp
@@ -1899,6 +1899,8 @@ qboolean Player::CondVariable(Conditional& condition)
     return qtrue;
 }
 
+#ifdef OPM_FEATURES
+
 qboolean Player::CondAnimDoneVM(Conditional& condition)
 {
     return animDoneVM;
@@ -1908,6 +1910,8 @@ qboolean Player::CondVMAnim(Conditional& condition)
 {
     return condition.getParm(1) == m_sVMcurrent;
 }
+
+#endif
 
 CLASS_DECLARATION(Class, Conditional, NULL) {
     {NULL, NULL}
@@ -2037,8 +2041,10 @@ Condition<Player> Player::m_conditions[] = {
     {"CLIENT_COMMAND",                  &Player::CondClientCommand           },
     {"VAR_OPERATOR",                    &Player::CondVariable                },
 
+#ifdef OPM_FEATURES
     // View model animation
     {"ANIMDONE_VM",                     &Player::CondAnimDoneVM              },
     {"IS_VM_ANIM",                      &Player::CondVMAnim                  },
+#endif
     {NULL,                              NULL                                 },
 };


### PR DESCRIPTION
Caching all FPS models would cause too many unnecessary entries. In some maps this would lead to clients reaching MAX_MOD_KNOWN limits, causing crashes.

Fixes  #828