### PR TITLE
feat(ui): properly support shaders with one-shot animated textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add the bot count (if there are any) in the server browser. This will only work for servers running at least the version **0.83.0** of OpenMoHAA. The bot count will also show on the [333networks](https://master.333networks.com/) master server website.
 
+#### Client
+
+- Add support for one-shot animated shaders in the UI (#838) (not supported in the original game).
+
 #### Platform
 
 - Allow separation of config, data, and state directories within the home path (XDG directory support) (#588).

--- a/code/client/cl_ui.cpp
+++ b/code/client/cl_ui.cpp
@@ -3797,6 +3797,8 @@ void CL_FillUIImports(void)
     uii.IsRendererLoaded  = CL_IsRendererLoaded;
     uii.Rend_LoadRawImage = re.LoadRawImage;
     uii.Rend_FreeRawImage = re.FreeRawImage;
+
+    uii.Rend_Set2DStartTime = re.Set2DInitialShaderTime;
 }
 
 /*

--- a/code/renderercommon/tr_public.h
+++ b/code/renderercommon/tr_public.h
@@ -178,6 +178,8 @@ typedef struct {
 
     qboolean (*LoadRawImage)(const char *name, byte **pic, int *width, int *height);
     void (*FreeRawImage)(byte *pic);
+
+    void (*Set2DInitialShaderTime)(float startTime);
 } refexport_t;
 
 //

--- a/code/renderergl1/tr_draw.c
+++ b/code/renderergl1/tr_draw.c
@@ -461,6 +461,7 @@ void Set2DWindow(int x, int y, int w, int h, float left, float right, float bott
 		backEnd.refdef.time = ri.Milliseconds();
 		backEnd.in2D = qtrue;
 		backEnd.refdef.floatTime = backEnd.refdef.time / 1000.0;
+        backEnd.shaderStartTime = 0; 
 	}
 }
 
@@ -472,4 +473,17 @@ RE_Scissor
 void RE_Scissor(int x, int y, int width, int height) {
 	qglEnable(GL_SCISSOR_TEST);
 	qglScissor(x, y, width, height);
+}
+
+/*
+================
+Set2DInitialShaderTime
+================
+*/
+void Set2DInitialShaderTime(float startTime)
+{
+	if (backEnd.in2D)
+	{
+		backEnd.shaderStartTime = startTime;
+	}
 }

--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -1971,5 +1971,7 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
     re.LoadRawImage = R_LoadRawImage;
     re.FreeRawImage = R_FreeRawImage;
 
+	re.Set2DInitialShaderTime = Set2DInitialShaderTime;
+
 	return &re;
 }

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -1764,6 +1764,10 @@ void Draw_TrianglePic(const vec2_t vPoints[3], const vec2_t vTexCoords[3], qhand
 void DrawBox(float x, float y, float w, float h);
 void AddBox(float x, float y, float w, float h);
 void Set2DWindow(int x, int y, int w, int h, float left, float right, float bottom, float top, float n, float f);
+
+// Added in OPM
+void Set2DInitialShaderTime(float startTime);
+
 void RE_Scissor(int x, int y, int width, int height);
 void DrawLineLoop(const vec2_t* points, int count, int stipple_factor, int stipple_mask);
 void RE_StretchRaw(int x, int y, int w, int h, int cols, int rows, int components, const byte* data);

--- a/code/renderergl1/tr_shade.c
+++ b/code/renderergl1/tr_shade.c
@@ -1518,7 +1518,7 @@ void RB_StageIteratorGeneric( void )
 	input = &tess;
 
 	input->shaderTime = backEnd.refdef.floatTime;
-	if ((input->shader->flags & 1) != 0) {
+	if ((input->shader->flags & BUNDLE_ANIMATE_ONCE) != 0) {
 		input->shaderTime = backEnd.refdef.floatTime - backEnd.shaderStartTime;
 	}
 

--- a/code/renderergl2/tr_draw.c
+++ b/code/renderergl2/tr_draw.c
@@ -533,3 +533,16 @@ void RE_Scissor(int x, int y, int width, int height) {
     qglEnable(GL_SCISSOR_TEST);
     qglScissor(x, y, width, height);
 }
+
+/*
+================
+Set2DInitialShaderTime
+================
+*/
+void Set2DInitialShaderTime(float startTime)
+{
+	if (backEnd.projection2D)
+	{
+		backEnd.shaderStartTime = startTime;
+	}
+}

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -2082,6 +2082,8 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
 
     re.LoadRawImage = R_LoadRawImage;
     re.FreeRawImage = R_FreeRawImage;
+    
+	re.Set2DInitialShaderTime = Set2DInitialShaderTime;
 
 	return &re;
 }

--- a/code/renderergl2/tr_local.h
+++ b/code/renderergl2/tr_local.h
@@ -3039,6 +3039,7 @@ void Draw_TrianglePic(const vec2_t vPoints[3], const vec2_t vTexCoords[3], qhand
 void DrawBox(float x, float y, float w, float h);
 void AddBox(float x, float y, float w, float h);
 void Set2DWindow(int x, int y, int w, int h, float left, float right, float bottom, float top, float n, float f);
+void Set2DInitialShaderTime(float startTime);
 void RE_Scissor(int x, int y, int width, int height);
 void DrawLineLoop(const vec2_t* points, int count, int stipple_factor, int stipple_mask);
 void RE_StretchRaw2(int x, int y, int w, int h, int cols, int rows, int components, const byte* data);

--- a/code/uilib/ui_public.h
+++ b/code/uilib/ui_public.h
@@ -152,6 +152,8 @@ typedef struct glconfig_t;*/
         qboolean (*IsRendererLoaded)(void);
         qboolean (*Rend_LoadRawImage)(const char *name, byte **pic, int *width, int *height);
         void (*Rend_FreeRawImage)(byte *pic);
+
+        void (*Rend_Set2DStartTime)(float startTime);
     } uiimport_t;
 
 #if 1

--- a/code/uilib/uiwidget.cpp
+++ b/code/uilib/uiwidget.cpp
@@ -705,6 +705,8 @@ UIWidget::UIWidget()
 
     UIRect2D frame(6.0f, 6.0f, 100.0f, 13.0f);
     setFrame(frame);
+
+    lastShowTime = -1;
 }
 
 UIWidget::~UIWidget()
@@ -857,6 +859,16 @@ void UIWidget::set2D(void)
         m_clippedframe.size.width,
         m_clippedframe.size.height
     );
+
+    //
+    // Added in OPM
+    //
+
+    if (lastShowTime == -1) {
+        lastShowTime = uii.Sys_Milliseconds() / 1000.0;
+    }
+
+    uii.Rend_Set2DStartTime(lastShowTime);
 }
 
 void UIWidget::Draw(void) {}
@@ -1612,6 +1624,9 @@ void UIWidget::Disable(void)
     for (i = 1; i <= n; i++) {
         m_children.ObjectAt(i)->Disable();
     }
+
+    // Added in OPM
+    lastShowTime = -1;
 }
 
 bool UIWidget::isEnabled(void)
@@ -1689,6 +1704,9 @@ void UIWidget::setShow(bool visible)
         if (IsThisOrChildActive()) {
             uWinMan.DeactivateCurrentSmart();
         }
+
+        // Added in OPM
+        lastShowTime = -1;
     }
 }
 
@@ -1900,6 +1918,7 @@ void UIWidget::Display(const UIRect2D& drawframe, float parent_alpha)
     vec4_t col = {1, 1, 1, 1};
 
     if (!isEnabled()) {
+        lastShowTime = -1;
         return;
     }
 

--- a/code/uilib/uiwidget.h
+++ b/code/uilib/uiwidget.h
@@ -165,9 +165,14 @@ protected:
     qboolean              m_bVirtual;
     str                   m_enabledCvar;
     //
-    // New since 2.0
+    // Added in 2.0
     //
     cvar_t *m_scaleCvar;
+
+    //
+    // Added in OPM
+    //
+    float lastShowTime;
 
 public:
     CLASS_PROTOTYPE(UIWidget);


### PR DESCRIPTION
The issue also occurs in the original game. One-shot animated shaders would always appear as already finished.

Fixes #838.