### PR TITLE
fix(fgame): createlistener must create a SimpleArchivedEntity instead of a Listener

### DIFF
--- a/code/fgame/scriptthread.cpp
+++ b/code/fgame/scriptthread.cpp
@@ -3917,7 +3917,8 @@ void ScriptThread::EventHideMouse(Event *ev)
 
 void ScriptThread::EventCreateListener(Event *ev)
 {
-    ev->AddListener(new Listener);
+    // Use a SimpleArchivedEntity so the object is automatically removed upon restart or map change
+    ev->AddListener(new SimpleArchivedEntity);
 }
 
 void ScriptThread::EventTrace(Event *ev)


### PR DESCRIPTION
This allows these objects to be removed upon map change or restart.
This also allows existing scripts to assign a targetname on the created object.

Fixes #849.