### PR TITLE
feat(fgame): send vote options between multiple client frames

### DIFF
--- a/code/fgame/bg_voteoptions.h
+++ b/code/fgame/bg_voteoptions.h
@@ -30,8 +30,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #ifdef __cplusplus
 
-static const unsigned long MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH = 2024;
 static const unsigned long MAX_VOTEOPTIONS_BUFFER_LENGTH        = 0x100000;
+static const unsigned long MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH = 2024;
+static const unsigned long MAX_VOTEOPTIONS_UPLOAD_BURST         = 5;
 
 typedef enum voteoptiontype_e {
     /** No input. */

--- a/code/fgame/clientvote.cpp
+++ b/code/fgame/clientvote.cpp
@@ -1,0 +1,114 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+#include "clientvote.h"
+#include "bg_voteoptions.h"
+#include "level.h"
+#include "game.h"
+
+CLASS_DECLARATION(Listener, VoteUpload, NULL) {
+    {NULL, NULL}
+};
+
+VoteUpload::VoteUpload()
+    : clientNum(-1)
+    , bufferToSend(NULL)
+{}
+
+VoteUpload::VoteUpload(int clientNum)
+    : VoteUpload()
+{
+    this->clientNum = clientNum;
+}
+
+void VoteUpload::StartSending(const VoteOptions& options)
+{
+    bufferLength = 0;
+    bufferToSend = options.GetVoteOptionsFile(&bufferLength);
+    offset       = 0;
+}
+
+bool VoteUpload::ClientThink()
+{
+    const char *cmd;
+    size_t      destLength;
+    size_t      i;
+    size_t      c;
+    char        buffer[2068];
+
+    if (bufferLength < MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH) {
+        //
+        // Small buffer
+        //
+
+        Q_strncpyz(buffer, bufferToSend, bufferLength + 1);
+
+        for (i = 0; i < bufferLength; i++) {
+            if (buffer[i] == '"') {
+                buffer[i] = 1;
+            }
+        }
+
+        gi.SendServerCommand(clientNum, "vo0 \"\"\n");
+        gi.SendServerCommand(clientNum, "vo2 \"%s\"\n", buffer);
+
+        return true;
+    }
+
+    for (c = 0; c < MAX_VOTEOPTIONS_UPLOAD_BURST; c++) {
+        if (gi.Client_NumPendingCommands(clientNum) + 2 > gi.Client_MaxPendingCommands(clientNum)) {
+            // Wait before sending new commands
+            break;
+        }
+
+        if (offset == 0) {
+            cmd        = "vo0";
+            destLength = MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH;
+        } else if ((bufferLength - offset) >= MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH) {
+            cmd        = "vo1";
+            destLength = MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH;
+        } else {
+            cmd        = "vo2";
+            destLength = bufferLength - offset;
+        }
+
+        Q_strncpyz(buffer, &bufferToSend[offset], MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH);
+
+        for (i = 0; i < destLength; i++) {
+            if (buffer[i] == '"') {
+                buffer[i] = 1;
+            }
+        }
+
+        gi.SendServerCommand(clientNum, "%s \"%s\"\n", cmd, buffer);
+        offset += MAX_VOTEOPTIONS_UPLOAD_BUFFER_LENGTH - 1;
+
+        if (offset >= bufferLength) {
+            //
+            // Finished sending
+            //
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/code/fgame/clientvote.h
+++ b/code/fgame/clientvote.h
@@ -1,0 +1,45 @@
+/*
+===========================================================================
+Copyright (C) 2025 the OpenMoHAA team
+
+This file is part of OpenMoHAA source code.
+
+OpenMoHAA source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+OpenMoHAA source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenMoHAA source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+#include "../corepp/listener.h"
+
+class VoteOptions;
+
+class VoteUpload : public Listener
+{
+public:
+    CLASS_PROTOTYPE(VoteUpload);
+
+public:
+    VoteUpload();
+    VoteUpload(int clientNum);
+
+    void StartSending(const VoteOptions& options);
+
+    bool ClientThink();
+
+private:
+    int clientNum;
+    int bufferLength;
+    const char *bufferToSend;
+    size_t offset;
+};

--- a/code/fgame/g_public.h
+++ b/code/fgame/g_public.h
@@ -498,6 +498,9 @@ typedef struct gameImport_s {
     void (*KickClientForReason)(int clientNum, const char *reason);
     cvar_t *(*Cvar_Find)(const char *varName);
 
+    unsigned int (*Client_NumPendingCommands)(int clientNum);
+    unsigned int (*Client_MaxPendingCommands)(int clientNum);
+
     cvar_t *fsDebug;
 
 } game_import_t;

--- a/code/fgame/level.cpp
+++ b/code/fgame/level.cpp
@@ -2817,6 +2817,11 @@ void Level::GetForceTeamObjectiveLocation(Event *ev)
     ev->AddInteger(g_gametype->integer >= GT_TOW || m_bForceTeamObjectiveLocation);
 }
 
+const VoteOptions& Level::GetVoteOptions() const
+{
+    return m_voteOptions;
+}
+
 badplace_t::badplace_t()
     : m_fLifespan(FLT_MAX)
     , m_iTeamSide(TEAM_ALLIES)

--- a/code/fgame/level.h
+++ b/code/fgame/level.h
@@ -378,6 +378,7 @@ public:
     // Added in OPM
     void SetForceTeamObjectiveLocation(Event *ev);
     void GetForceTeamObjectiveLocation(Event *ev);
+    const VoteOptions& GetVoteOptions() const;
     //====
 
     void Archive(Archiver& arc) override;

--- a/code/fgame/player.h
+++ b/code/fgame/player.h
@@ -123,6 +123,8 @@ typedef struct vma_s {
 #define MAX_ANIM_SLOT         16
 #define MAX_TRAILS            2
 
+class VoteUpload;
+
 class Player : public Sentient
 {
     friend class Camera;
@@ -360,7 +362,6 @@ public:
     //
     // Added in OPM
     //
-    str               m_sVision;    // current vision
     str               m_sStateFile; // custom statefile
     bool              m_bFrozen;    // if player is frozen
     float             speed_multiplier[MAX_SPEED_MULTIPLIERS];
@@ -368,7 +369,10 @@ public:
     bool              m_bConnected;
     str               m_lastcommand;
 
+    VoteUpload *voteUpload;
+
 #ifdef OPM_FEATURES
+    str m_sVision; // current vision
     //
     // View model animation
     //
@@ -787,7 +791,7 @@ public:
     void ResetHaveItem(Event *ev);
 
     void ModifyHeight(Event *ev);
-     // Added in 2.40
+    // Added in 2.40
     void ModifyHeightFloat(Event *ev);
 
     void SetMovePosFlags(Event *ev);

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -524,6 +524,9 @@ int SV_SendQueuedMessages(void);
 
 void SV_KickClientForReason(client_t *cl, const char *reason);
 
+unsigned int SV_Client_GetNumPendingCommands(client_t *cl);
+unsigned int SV_Client_GetMaxPendingCommands(client_t *cl);
+
 
 //
 // sv_ccmds.c

--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -2195,3 +2195,13 @@ void SV_KickClientForReason(client_t *cl, const char *reason)
         SV_DropClient(cl, "was kicked");
     }
 }
+
+unsigned int SV_Client_GetNumPendingCommands(client_t *cl)
+{
+	return cl->reliableSequence - cl->reliableAcknowledge;
+}
+
+unsigned int SV_Client_GetMaxPendingCommands(client_t *cl)
+{
+	return MAX_RELIABLE_COMMANDS;
+}

--- a/code/server/sv_game.c
+++ b/code/server/sv_game.c
@@ -1716,6 +1716,24 @@ void SV_GameKickClientForReason( int clientNum, const char *reason ) {
 	SV_KickClientForReason( svs.clients + clientNum, reason );	
 }
 
+unsigned int PF_SV_Client_NumPendingCommands(int clientNum)
+{
+	if ( clientNum < 0 || clientNum >= sv_maxclients->integer ) {
+		return 0;
+	}
+
+	return SV_Client_GetNumPendingCommands(svs.clients + clientNum);
+}
+
+unsigned int PF_SV_Client_MaxPendingCommands(int clientNum)
+{
+	if ( clientNum < 0 || clientNum >= sv_maxclients->integer ) {
+		return 0;
+	}
+
+	return SV_Client_GetMaxPendingCommands(svs.clients + clientNum);
+}
+
 /*
 ===============
 SV_InitGameProgs
@@ -1931,6 +1949,9 @@ void SV_InitGameProgs( void ) {
 	import.KickClientForReason			= SV_GameKickClientForReason;
 
     import.Cvar_Find                    = Cvar_FindVar;
+    
+    import.Client_NumPendingCommands	= PF_SV_Client_NumPendingCommands;
+    import.Client_MaxPendingCommands	= PF_SV_Client_MaxPendingCommands;
 
 	ge = Sys_GetGameAPI( &import );
 


### PR DESCRIPTION
It is now possible for servers to send large vote configuration files to clients without causing disconnections due to packets being larger than 50 KB.
The issue also occurs on vanilla servers.

The hard limit for the configuration file is still 1 MB.

Fixes #858.