### PR TITLE
Fix server address persistence for reconnect.

### DIFF
--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1389,9 +1389,6 @@ void CL_Connect( const char *server, netadrtype_t family ) {
 	clc.connectTime = -99999;	// CL_CheckForResend() will fire immediately
 	clc.connectPacketCount = 0;
 	clc.connectStartTime = cls.realtime;
-
-	// server connection string
-	Cvar_Set( "cl_currentServerAddress", server );
 }
 
 /*


### PR DESCRIPTION
https://github.com/openmoh/openmohaa/issues/877

Reconnect relied on clc.servername, which wasn't fine, because value WAS stored on entry into CL_Disconnect, but was "zero'ed" at the end of it, resulting in inability to reconnect.

Fixed it by making a persistent cl_currentServerAddress. Happy to fix the code if there are things to point out.