### PR TITLE
fix: Buffer overflow in CM_EdgePlaneNum

### DIFF
--- a/code/qcommon/cm_patch.c
+++ b/code/qcommon/cm_patch.c
@@ -585,6 +585,9 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRI
 		p1 = grid->points[i][j];
 		p2 = grid->points[i+1][j];
 		p = CM_GridPlane( gridPlanes, i, j, 0 );
+		if ( p == -1 ) {
+			return -1;
+		}
 		VectorMA( p1, 4, planes[ p ].plane, up );
 		return CM_FindPlane( p1, p2, up );
 
@@ -592,6 +595,9 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRI
 		p1 = grid->points[i][j+1];
 		p2 = grid->points[i+1][j+1];
 		p = CM_GridPlane( gridPlanes, i, j, 1 );
+		if ( p == -1 ) {
+			return -1;
+		}
 		VectorMA( p1, 4, planes[ p ].plane, up );
 		return CM_FindPlane( p2, p1, up );
 
@@ -599,6 +605,9 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRI
 		p1 = grid->points[i][j];
 		p2 = grid->points[i][j+1];
 		p = CM_GridPlane( gridPlanes, i, j, 1 );
+		if ( p == -1 ) {
+			return -1;
+		}
 		VectorMA( p1, 4, planes[ p ].plane, up );
 		return CM_FindPlane( p2, p1, up );
 
@@ -606,6 +615,9 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRI
 		p1 = grid->points[i+1][j];
 		p2 = grid->points[i+1][j+1];
 		p = CM_GridPlane( gridPlanes, i, j, 0 );
+		if ( p == -1 ) {
+			return -1;
+		}
 		VectorMA( p1, 4, planes[ p ].plane, up );
 		return CM_FindPlane( p1, p2, up );
 
@@ -613,6 +625,9 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRI
 		p1 = grid->points[i+1][j+1];
 		p2 = grid->points[i][j];
 		p = CM_GridPlane( gridPlanes, i, j, 0 );
+		if ( p == -1 ) {
+			return -1;
+		}
 		VectorMA( p1, 4, planes[ p ].plane, up );
 		return CM_FindPlane( p1, p2, up );
 
@@ -620,6 +635,9 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRI
 		p1 = grid->points[i][j];
 		p2 = grid->points[i+1][j+1];
 		p = CM_GridPlane( gridPlanes, i, j, 1 );
+		if ( p == -1 ) {
+			return -1;
+		}
 		VectorMA( p1, 4, planes[ p ].plane, up );
 		return CM_FindPlane( p1, p2, up );
 


### PR DESCRIPTION
When loading map `m4l3` in Breakthrough, game crashed during patch collision generation:

```
code/qcommon/cm_patch.c:588: runtime error: index -1 out of bounds for type 'patchPlane_t [6144]'
==99755==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55b329ee63ac
  at pc 0x55b327812278 bp 0x7ffc9502dd10 sp 0x7ffc9502dd00
READ of size 4 at 0x55b329ee63ac thread T0
    #0 CM_EdgePlaneNum     code/qcommon/cm_patch.c:588
    #1 CM_PatchCollideFromGrid  code/qcommon/cm_patch.c:974
    #2 CM_GeneratePatchCollide  code/qcommon/cm_patch.c:1185
    #3 CMod_LoadPatches         code/qcommon/cm_load.c:679
    #4 CM_LoadMap                code/qcommon/cm_load.c:919
```

Game: OpenMOHAA specific bug, works in vanilla.
Steps to reproduce:

- download coop mod.
- launch server with m4l3 map, you should crash on load.

Crash occurs only when launching locally, through client, and when launching m4l3 map as a "multiplayer" map. On dedicated it works.