### PR TITLE
fix(fgame): prevent wrong pointer access in Actor::Think_MachineGunner_TurretGun

### DIFF
--- a/code/fgame/actor_machinegunner.cpp
+++ b/code/fgame/actor_machinegunner.cpp
@@ -220,7 +220,10 @@ void Actor::Think_MachineGunner_TurretGun(void)
         return;
     }
 
+    // FIXME: Add support for multiple players
+
     player = G_GetEntity(0);
+    // Fixed in OPM
     if (!player) {
          return; 
     }


### PR DESCRIPTION
After fixing crash from https://github.com/openmoh/openmohaa/pull/895 :

```
code/fgame/actor_machinegunner.cpp:221:49: runtime error:
  member access within null pointer of type 'struct Entity'

Backtrace:
=> game.so  TurretGun::AI_CanTarget(float const*)+0x147
=> game.so  Actor::Think_MachineGunner_TurretGun()+0x636
=> game.so  Actor::Think()+0x11ee
=> game.so  G_RunEntity(Entity*)+0x2e6
=> game.so  G_RunFrame(int, int)+0x1805
fish: terminated by signal SIGABRT
```

Same reproduction steps as in PR with CM_EdgePnaneNum.